### PR TITLE
Phase 1: Garuda foundation modules + module work breakdown

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,0 +1,148 @@
+# Garuda — Module Work Breakdown
+
+Build order: **bottom-up**. Each module has a status, dependencies, and exit criteria.
+
+| Status | Meaning |
+|--------|---------|
+| ✅ | Done |
+| 🚧 | In progress |
+| ⬜ | Not started |
+
+---
+
+## Dependency Graph
+
+```
+types ──┬── model ──┬── core/loop ─── interfaces/cli
+        │           │
+workspace ──┬── tools ──┘
+            │
+        core/events
+            │
+        context (Phase 2)
+        permissions (Phase 2)
+        verifier (Phase 2)
+            │
+        agents/loader (Phase 2)
+            │
+        workspace/docker, tmux (Phase 3)
+        tools/mcp (Phase 4)
+            │
+        eval/harbor (Phase 5)
+```
+
+---
+
+## Phase 1 — Foundation (MVP)
+
+| # | Module | Path | Status | Depends On | Exit Criteria |
+|---|--------|------|--------|------------|---------------|
+| M1 | **Types** | `garuda/types.py` | ✅ | — | Message, ToolCall, AgentConfig dataclasses |
+| M2 | **Model protocol** | `garuda/model/` | ✅ | M1 | `Model` protocol + `LitellmModel` + `ScriptModel` (tests) |
+| M3 | **Environment** | `garuda/workspace/local.py` | ✅ | M1 | bash exec, read/write files in workspace |
+| M4 | **Tools** | `garuda/tools/` | ✅ | M1, M3 | `bash`, `read_file`, `write_file` |
+| M5 | **Event store** | `garuda/core/events.py` | ✅ | M1 | Append-only JSONL log |
+| M6 | **Agent loop** | `garuda/core/loop.py` | ✅ | M2–M5 | `DefaultAgent` runs multi-turn with tools |
+| M7 | **Headless CLI** | `garuda/interfaces/headless.py` | ✅ | M6 | `garuda run -t "task"` works |
+
+**Phase 1 exit:** Run a local task end-to-end with any LiteLLM model (or `ScriptModel` in tests).
+
+---
+
+## Phase 2 — Reliability
+
+| # | Module | Path | Status | Depends On | Exit Criteria |
+|---|--------|------|--------|------------|---------------|
+| M8 | **Context manager** | `garuda/context/` | ⬜ | M2, M6 | Output caps, head/tail shaping |
+| M9 | **Permissions** | `garuda/core/permissions.py` | ⬜ | M4 | allow/deny/ask per tool/command |
+| M10 | **Completion verifier** | `garuda/core/verifier.py` | ⬜ | M2, M6 | Checklist gate on `task_complete` |
+| M11 | **Patch tool** | `garuda/tools/patch.py` | ⬜ | M3 | Unified diff apply |
+| M12 | **Agent profiles** | `garuda/agents/` | ⬜ | M6, M9 | Load `build`/`plan`/`explore` from YAML |
+| M13 | **Interactive CLI** | `garuda/interfaces/cli.py` | ⬜ | M6, M9 | TUI with permission prompts |
+
+**Phase 2 exit:** Multi-turn task with permissions and completion verification.
+
+---
+
+## Phase 3 — Terminal Realism
+
+| # | Module | Path | Status | Depends On | Exit Criteria |
+|---|--------|------|--------|------------|---------------|
+| M14 | **Tmux environment** | `garuda/workspace/tmux.py` | ⬜ | M3 | Persistent tmux session |
+| M15 | **Tmux tools** | `garuda/tools/tmux.py` | ⬜ | M14 | `tmux_send`, `tmux_capture` |
+| M16 | **Marker polling** | `garuda/workspace/tmux.py` | ⬜ | M14 | `__CMDEND__` early completion |
+| M17 | **Summarizer** | `garuda/context/summarizer.py` | ⬜ | M8 | 3-step proactive summarization |
+| M18 | **Image read** | `garuda/tools/image_read.py` | ⬜ | M2 | Multimodal file analysis |
+| M19 | **Docker workspace** | `garuda/workspace/docker.py` | ⬜ | M3 | Container-isolated execution |
+
+**Phase 3 exit:** Interactive terminal task (pager, server, menu) via tmux.
+
+---
+
+## Phase 4 — Extensibility
+
+| # | Module | Path | Status | Depends On | Exit Criteria |
+|---|--------|------|--------|------------|---------------|
+| M20 | **MCP client** | `garuda/tools/mcp.py` | ⬜ | M4 | Connect stdio MCP servers |
+| M21 | **Plugin hooks** | `garuda/plugins/hooks.py` | ⬜ | M6 | before/after tool lifecycle |
+| M22 | **Subagent handoff** | `garuda/core/subagent.py` | ⬜ | M8, M12 | Fork context, return summary |
+| M23 | **Task complete tool** | `garuda/tools/task_complete.py` | ⬜ | M10 | Triggers verifier |
+
+**Phase 4 exit:** Custom YAML agent profile + MCP tool in Docker.
+
+---
+
+## Phase 5 — Evaluation
+
+| # | Module | Path | Status | Depends On | Exit Criteria |
+|---|--------|------|--------|------------|---------------|
+| M24 | **ATIF export** | `garuda/eval/atif_export.py` | ⬜ | M5 | EventStore → ATIF JSON |
+| M25 | **Harbor adapter** | `garuda/eval/harbor_adapter.py` | ⬜ | M6, M19 | `BaseAgent` implementation |
+| M26 | **TB benchmarks** | `garuda/eval/benchmarks/` | ⬜ | M25 | Harbor run configs |
+| M27 | **Spreadsheet eval** | `garuda/eval/benchmarks/spreadsheet/` | ⬜ | M25 | SpreadsheetBench adapter (eval only) |
+| M28 | **PDF eval** | `garuda/eval/benchmarks/pdf/` | ⬜ | M25 | OfficeQA adapter (eval only) |
+
+**Phase 5 exit:** Score on Terminal-Bench 2.0 via Harbor with ATIF logs.
+
+---
+
+## Phase 6 — Production (v1.5+)
+
+| # | Module | Path | Status | Depends On |
+|---|--------|------|--------|------------|
+| M29 | Recipes | `garuda/config/recipes.py` | ⬜ | M12 |
+| M30 | RigorousAgent | `garuda/core/rigorous.py` | ⬜ | M10, M17 |
+| M31 | IDE server | `garuda/interfaces/server.py` | ⬜ | M6 |
+| M32 | OS sandbox | `garuda/workspace/sandbox.py` | ⬜ | M3 |
+| M33 | Remote workspace | `garuda/workspace/remote.py` | ⬜ | M19 |
+
+---
+
+## Current Sprint
+
+**Building now:** Phase 1 (M1–M7)
+
+**Next up:** Phase 2 (M8–M13)
+
+---
+
+## How to Work Module-by-Module
+
+1. Pick the next ⬜ module whose dependencies are ✅
+2. Implement module + unit tests in `tests/`
+3. Update status in this file
+4. PR per phase (or per module for large phases)
+
+```bash
+# Install
+pip install -e ".[dev]"
+
+# Run tests
+pytest tests/ -v
+
+# Run agent (needs API key)
+garuda run -t "List files in the current directory"
+
+# Run with explicit model
+garuda run -t "..." --model openai/gpt-4o-mini
+```

--- a/garuda/__init__.py
+++ b/garuda/__init__.py
@@ -1,0 +1,3 @@
+"""Garuda Open Agent — universal provider-agnostic agent harness."""
+
+__version__ = "0.1.0"

--- a/garuda/core/events.py
+++ b/garuda/core/events.py
@@ -1,0 +1,55 @@
+import json
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from garuda.types import Message
+
+
+class EventType(str, Enum):
+    USER_MESSAGE = "user_message"
+    MODEL_RESPONSE = "model_response"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    SESSION_START = "session_start"
+    SESSION_END = "session_end"
+
+
+class EventStore:
+    def __init__(self, session_id: str | None = None):
+        self.session_id = session_id or str(uuid.uuid4())
+        self._events: list[dict[str, Any]] = []
+
+    def append(self, event_type: EventType, payload: dict[str, Any]) -> None:
+        self._events.append(
+            {
+                "type": event_type.value,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "session_id": self.session_id,
+                "payload": payload,
+            }
+        )
+
+    def get_all(self) -> list[dict[str, Any]]:
+        return list(self._events)
+
+    def save(self, path: str | Path) -> None:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        lines = [json.dumps(event) for event in self._events]
+        target.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> "EventStore":
+        store = cls()
+        for line in Path(path).read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                store._events.append(json.loads(line))
+        if store._events:
+            store.session_id = store._events[0].get("session_id", store.session_id)
+        return store
+
+    def messages_snapshot(self, messages: list[Message]) -> list[dict[str, str]]:
+        return [{"role": m.role.value, "content": m.content} for m in messages]

--- a/garuda/core/loop.py
+++ b/garuda/core/loop.py
@@ -1,0 +1,159 @@
+import json
+import uuid
+
+from garuda.core.events import EventStore, EventType
+from garuda.model.protocol import Model
+from garuda.tools.protocol import Tool, ToolContext
+from garuda.types import (
+    DEFAULT_SYSTEM_PROMPT,
+    AgentConfig,
+    AgentResult,
+    Message,
+    Role,
+    ToolCall,
+)
+from garuda.workspace.protocol import Environment
+
+
+def _tools_schema(tools: list[Tool]) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            },
+        }
+        for tool in tools
+    ]
+
+
+def _shape_output(text: str, max_bytes: int) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    half = max_bytes // 2
+    head = encoded[:half].decode("utf-8", errors="ignore")
+    tail = encoded[-half:].decode("utf-8", errors="ignore")
+    return f"{head}\n\n...[truncated]...\n\n{tail}"
+
+
+class DefaultAgent:
+    def __init__(self, profile_name: str = "build"):
+        self._profile_name = profile_name
+
+    @property
+    def profile_name(self) -> str:
+        return self._profile_name
+
+    async def run(
+        self,
+        task: str,
+        model: Model,
+        env: Environment,
+        tools: list[Tool],
+        config: AgentConfig | None = None,
+        events: EventStore | None = None,
+    ) -> AgentResult:
+        config = config or AgentConfig()
+        events = events or EventStore()
+        events.append(EventType.SESSION_START, {"task": task, "model": model.model_name})
+
+        tool_map = {tool.name: tool for tool in tools}
+        if config.allowed_tools:
+            tool_map = {name: tool_map[name] for name in config.allowed_tools if name in tool_map}
+            tools = list(tool_map.values())
+
+        system_prompt = config.system_prompt or DEFAULT_SYSTEM_PROMPT
+        messages: list[Message] = [
+            Message(role=Role.SYSTEM, content=system_prompt),
+            Message(role=Role.USER, content=task),
+        ]
+        events.append(EventType.USER_MESSAGE, {"content": task})
+
+        ctx = ToolContext(session_id=events.session_id, agent_profile=self._profile_name)
+        final_message = ""
+
+        for turn in range(1, config.max_turns + 1):
+            response = await model.complete(messages, tools=_tools_schema(tools))
+            events.append(
+                EventType.MODEL_RESPONSE,
+                {
+                    "content": response.content,
+                    "tool_calls": [
+                        {"name": c.name, "arguments": c.arguments} for c in response.tool_calls
+                    ],
+                },
+            )
+
+            if response.content:
+                messages.append(Message(role=Role.ASSISTANT, content=response.content))
+
+            if not response.tool_calls:
+                final_message = response.content or ""
+                if self._is_completion_message(final_message):
+                    events.append(EventType.SESSION_END, {"success": True, "turns": turn})
+                    return AgentResult(
+                        success=True,
+                        final_message=final_message,
+                        messages=messages,
+                        turns=turn,
+                        metadata={"session_id": events.session_id, "events": events.get_all()},
+                    )
+                continue
+
+            for call in response.tool_calls:
+                tool_result = await self._execute_tool(call, tool_map, env, ctx, config.max_output_bytes)
+                events.append(
+                    EventType.TOOL_CALL,
+                    {"name": call.name, "arguments": call.arguments},
+                )
+                events.append(
+                    EventType.TOOL_RESULT,
+                    {"name": call.name, "content": tool_result.content, "is_error": tool_result.is_error},
+                )
+                messages.append(
+                    Message(
+                        role=Role.TOOL,
+                        content=tool_result.content,
+                        name=call.name,
+                        tool_call_id=call.id,
+                    )
+                )
+
+        events.append(EventType.SESSION_END, {"success": False, "reason": "max_turns"})
+        return AgentResult(
+            success=False,
+            final_message=final_message or "Max turns exceeded",
+            messages=messages,
+            turns=config.max_turns,
+            metadata={"session_id": events.session_id, "events": events.get_all()},
+        )
+
+    async def _execute_tool(
+        self,
+        call: ToolCall,
+        tool_map: dict[str, Tool],
+        env: Environment,
+        ctx: ToolContext,
+        max_output_bytes: int,
+    ):
+        from garuda.types import ToolResult
+
+        tool = tool_map.get(call.name)
+        if tool is None:
+            return ToolResult(
+                tool_call_id=call.id,
+                content=f"Unknown tool: {call.name}",
+                is_error=True,
+            )
+        result = await tool.execute(call.arguments, env, ctx)
+        result.tool_call_id = call.id
+        result.content = _shape_output(result.content, max_output_bytes)
+        return result
+
+    def _is_completion_message(self, text: str) -> bool:
+        lowered = text.lower()
+        markers = ("task complete", "done.", "finished", "completed the task")
+        return any(marker in lowered for marker in markers)

--- a/garuda/interfaces/headless.py
+++ b/garuda/interfaces/headless.py
@@ -1,0 +1,79 @@
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+from garuda.core.events import EventStore
+from garuda.core.loop import DefaultAgent
+from garuda.model.litellm_model import LitellmModel
+from garuda.tools import default_tools
+from garuda.types import AgentConfig
+from garuda.workspace.local import LocalEnvironment
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="garuda", description="Garuda Open Agent harness")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Run an agent task")
+    run_parser.add_argument("-t", "--task", help="Task description")
+    run_parser.add_argument("-f", "--file", help="Read task from file")
+    run_parser.add_argument("--model", default=os.environ.get("GARUDA_MODEL", "openai/gpt-4o-mini"))
+    run_parser.add_argument("--workspace", default=".", help="Workspace root directory")
+    run_parser.add_argument("--max-turns", type=int, default=30)
+    run_parser.add_argument("--json", action="store_true", help="Print JSONL events to stdout")
+    run_parser.add_argument(
+        "--trajectory",
+        help="Save event trajectory to JSONL file",
+    )
+    return parser
+
+
+async def run_task(args: argparse.Namespace) -> int:
+    task = args.task
+    if args.file:
+        task = open(args.file, encoding="utf-8").read()
+    if not task:
+        print("Error: provide -t/--task or -f/--file", file=sys.stderr)
+        return 1
+
+    model = LitellmModel(model_name=args.model)
+    env = LocalEnvironment(workspace_root=args.workspace)
+    agent = DefaultAgent()
+    events = EventStore()
+    tools = default_tools()
+    config = AgentConfig(max_turns=args.max_turns)
+
+    result = await agent.run(
+        task=task,
+        model=model,
+        env=env,
+        tools=tools,
+        config=config,
+        events=events,
+    )
+
+    if args.trajectory:
+        events.save(args.trajectory)
+
+    if args.json:
+        for event in events.get_all():
+            print(json.dumps(event))
+    else:
+        print(result.final_message)
+
+    return 0 if result.success else 1
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.command == "run":
+        raise SystemExit(asyncio.run(run_task(args)))
+    parser.print_help()
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/garuda/model/__init__.py
+++ b/garuda/model/__init__.py
@@ -1,0 +1,5 @@
+from garuda.model.litellm_model import LitellmModel
+from garuda.model.protocol import Model, ModelResponse
+from garuda.model.script_model import ScriptModel
+
+__all__ = ["LitellmModel", "Model", "ModelResponse", "ScriptModel"]

--- a/garuda/model/litellm_model.py
+++ b/garuda/model/litellm_model.py
@@ -1,0 +1,112 @@
+import json
+import re
+import uuid
+
+import litellm
+
+from garuda.model.protocol import ModelResponse
+from garuda.types import Message, Role, ToolCall
+
+
+def _message_to_litellm(message: Message) -> dict:
+    payload: dict = {"role": message.role.value, "content": message.content}
+    if message.name:
+        payload["name"] = message.name
+    if message.tool_call_id:
+        payload["tool_call_id"] = message.tool_call_id
+    return payload
+
+
+def _parse_tool_calls(raw_calls: list) -> list[ToolCall]:
+    parsed: list[ToolCall] = []
+    for call in raw_calls:
+        fn = call.function if hasattr(call, "function") else call.get("function", {})
+        name = fn.name if hasattr(fn, "name") else fn.get("name", "")
+        raw_args = fn.arguments if hasattr(fn, "arguments") else fn.get("arguments", "{}")
+        arguments = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        call_id = call.id if hasattr(call, "id") else call.get("id", str(uuid.uuid4()))
+        parsed.append(ToolCall(id=call_id, name=name, arguments=arguments))
+    return parsed
+
+
+def parse_bash_blocks(text: str) -> list[ToolCall]:
+    """Extract bash commands from markdown fences for non-tool-calling models."""
+    pattern = re.compile(r"```(?:bash|sh|shell)?\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
+    calls: list[ToolCall] = []
+    for index, match in enumerate(pattern.finditer(text)):
+        command = match.group(1).strip()
+        if command:
+            calls.append(
+                ToolCall(
+                    id=f"bash-{index}",
+                    name="bash",
+                    arguments={"command": command},
+                )
+            )
+    return calls
+
+
+class LitellmModel:
+    def __init__(self, model_name: str, api_key: str | None = None, api_base: str | None = None):
+        self._model_name = model_name
+        self._api_key = api_key
+        self._api_base = api_base
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[dict] | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> ModelResponse:
+        kwargs: dict = {
+            "model": self._model_name,
+            "messages": [_message_to_litellm(m) for m in messages],
+        }
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        if self._api_base:
+            kwargs["api_base"] = self._api_base
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+
+        response = await litellm.acompletion(**kwargs)
+        choice = response.choices[0]
+        message = choice.message
+        content = message.content
+        raw_tool_calls = message.tool_calls or []
+        tool_calls = _parse_tool_calls(raw_tool_calls)
+
+        if not tool_calls and content:
+            tool_calls = parse_bash_blocks(content)
+
+        usage = {}
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.prompt_tokens or 0,
+                "completion_tokens": response.usage.completion_tokens or 0,
+            }
+
+        return ModelResponse(
+            content=content,
+            tool_calls=tool_calls,
+            raw={"model": self._model_name},
+            usage=usage,
+        )
+
+    def count_tokens(self, messages: list[Message]) -> int:
+        text = "\n".join(m.content for m in messages)
+        return len(text) // 4

--- a/garuda/model/protocol.py
+++ b/garuda/model/protocol.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from garuda.types import Message
+
+
+@dataclass
+class ModelResponse:
+    content: str | None
+    tool_calls: list[Any]
+    raw: dict[str, Any] = field(default_factory=dict)
+    usage: dict[str, int] = field(default_factory=dict)
+
+
+@runtime_checkable
+class Model(Protocol):
+    @property
+    def model_name(self) -> str: ...
+
+    @property
+    def supports_tool_calling(self) -> bool: ...
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[dict] | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> ModelResponse: ...
+
+    def count_tokens(self, messages: list[Message]) -> int: ...

--- a/garuda/model/script_model.py
+++ b/garuda/model/script_model.py
@@ -1,0 +1,32 @@
+from garuda.model.protocol import ModelResponse
+from garuda.types import Message
+
+
+class ScriptModel:
+    """Deterministic model for tests — returns queued responses in order."""
+
+    def __init__(self, responses: list[ModelResponse], model_name: str = "script/test"):
+        self._responses = list(responses)
+        self._model_name = model_name
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[dict] | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> ModelResponse:
+        if not self._responses:
+            return ModelResponse(content="Done.", tool_calls=[])
+        return self._responses.pop(0)
+
+    def count_tokens(self, messages: list[Message]) -> int:
+        return sum(len(m.content) for m in messages) // 4

--- a/garuda/tools/__init__.py
+++ b/garuda/tools/__init__.py
@@ -1,0 +1,9 @@
+from garuda.tools.bash import BashTool
+from garuda.tools.files import ReadFileTool, WriteFileTool
+from garuda.tools.protocol import Tool
+
+__all__ = ["BashTool", "ReadFileTool", "WriteFileTool", "default_tools"]
+
+
+def default_tools() -> list[Tool]:
+    return [BashTool(), ReadFileTool(), WriteFileTool()]

--- a/garuda/tools/bash.py
+++ b/garuda/tools/bash.py
@@ -1,0 +1,36 @@
+from garuda.tools.protocol import ToolContext
+from garuda.types import ToolResult
+from garuda.workspace.protocol import Environment
+
+
+class BashTool:
+    name = "bash"
+    description = "Execute a shell command in the workspace and return stdout, stderr, and exit code."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "command": {"type": "string", "description": "Shell command to execute"},
+        },
+        "required": ["command"],
+    }
+
+    async def execute(
+        self,
+        arguments: dict,
+        env: Environment,
+        ctx: ToolContext,
+    ) -> ToolResult:
+        command = arguments["command"]
+        result = await env.execute(command)
+        output = (
+            f"exit_code: {result.exit_code}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        ).strip()
+        if not result.stdout and not result.stderr:
+            output = f"exit_code: {result.exit_code}\nCommand ran successfully with no output."
+        return ToolResult(
+            tool_call_id="",
+            content=output,
+            is_error=result.exit_code != 0,
+        )

--- a/garuda/tools/files.py
+++ b/garuda/tools/files.py
@@ -1,0 +1,46 @@
+from garuda.tools.protocol import ToolContext
+from garuda.types import ToolResult
+from garuda.workspace.protocol import Environment
+
+
+class ReadFileTool:
+    name = "read_file"
+    description = "Read a text file from the workspace."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "File path relative to workspace or absolute"},
+        },
+        "required": ["path"],
+    }
+
+    async def execute(
+        self,
+        arguments: dict,
+        env: Environment,
+        ctx: ToolContext,
+    ) -> ToolResult:
+        content = await env.read_file(arguments["path"])
+        return ToolResult(tool_call_id="", content=content)
+
+
+class WriteFileTool:
+    name = "write_file"
+    description = "Write content to a file in the workspace."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "File path relative to workspace or absolute"},
+            "content": {"type": "string", "description": "Full file content to write"},
+        },
+        "required": ["path", "content"],
+    }
+
+    async def execute(
+        self,
+        arguments: dict,
+        env: Environment,
+        ctx: ToolContext,
+    ) -> ToolResult:
+        await env.write_file(arguments["path"], arguments["content"])
+        return ToolResult(tool_call_id="", content=f"Wrote {arguments['path']}")

--- a/garuda/tools/protocol.py
+++ b/garuda/tools/protocol.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from garuda.types import ToolResult
+from garuda.workspace.protocol import Environment
+
+
+@dataclass
+class ToolContext:
+    session_id: str
+    agent_profile: str = "build"
+
+
+@runtime_checkable
+class Tool(Protocol):
+    name: str
+    description: str
+    parameters: dict[str, Any]
+
+    async def execute(
+        self,
+        arguments: dict[str, Any],
+        env: Environment,
+        ctx: ToolContext,
+    ) -> ToolResult: ...

--- a/garuda/types.py
+++ b/garuda/types.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Role(str, Enum):
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+@dataclass
+class Message:
+    role: Role
+    content: str
+    name: str | None = None
+    tool_call_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass
+class ToolResult:
+    tool_call_id: str
+    content: str
+    is_error: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ExecResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+    duration_ms: int
+    truncated: bool = False
+
+
+@dataclass
+class AgentConfig:
+    max_turns: int = 200
+    mode: str = "standard"
+    permission_mode: str = "auto"
+    max_output_bytes: int = 30_720
+    system_prompt: str | None = None
+    allowed_tools: list[str] | None = None
+
+
+@dataclass
+class AgentResult:
+    success: bool
+    final_message: str
+    messages: list[Message]
+    turns: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+DEFAULT_SYSTEM_PROMPT = """You are Garuda, a capable software engineering agent.
+You solve tasks by using tools: bash commands, reading files, and writing files.
+Think step by step. Use tools to inspect the environment before making changes.
+When the task is fully complete, respond with a clear summary of what you did."""

--- a/garuda/workspace/__init__.py
+++ b/garuda/workspace/__init__.py
@@ -1,0 +1,3 @@
+from garuda.workspace.local import LocalEnvironment
+
+__all__ = ["LocalEnvironment"]

--- a/garuda/workspace/local.py
+++ b/garuda/workspace/local.py
@@ -1,0 +1,56 @@
+import asyncio
+import time
+from pathlib import Path
+
+from garuda.types import ExecResult
+
+
+class LocalEnvironment:
+    def __init__(self, workspace_root: str | Path | None = None):
+        self._workspace_root = Path(workspace_root or Path.cwd()).resolve()
+
+    @property
+    def workspace_root(self) -> str:
+        return str(self._workspace_root)
+
+    def _resolve_path(self, path: str) -> Path:
+        candidate = Path(path)
+        if candidate.is_absolute():
+            return candidate
+        return self._workspace_root / candidate
+
+    async def execute(
+        self,
+        command: str,
+        timeout: float | None = 120.0,
+        cwd: str | None = None,
+    ) -> ExecResult:
+        workdir = Path(cwd) if cwd else self._workspace_root
+        start = time.monotonic()
+
+        process = await asyncio.create_subprocess_shell(
+            command,
+            cwd=str(workdir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            process.communicate(),
+            timeout=timeout,
+        )
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return ExecResult(
+            stdout=stdout_bytes.decode(errors="replace"),
+            stderr=stderr_bytes.decode(errors="replace"),
+            exit_code=process.returncode or 0,
+            duration_ms=duration_ms,
+        )
+
+    async def read_file(self, path: str) -> str:
+        target = self._resolve_path(path)
+        return await asyncio.to_thread(target.read_text, encoding="utf-8")
+
+    async def write_file(self, path: str, content: str) -> None:
+        target = self._resolve_path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(target.write_text, content, encoding="utf-8")

--- a/garuda/workspace/protocol.py
+++ b/garuda/workspace/protocol.py
@@ -1,0 +1,20 @@
+from typing import Protocol, runtime_checkable
+
+from garuda.types import ExecResult
+
+
+@runtime_checkable
+class Environment(Protocol):
+    async def execute(
+        self,
+        command: str,
+        timeout: float | None = None,
+        cwd: str | None = None,
+    ) -> ExecResult: ...
+
+    async def read_file(self, path: str) -> str: ...
+
+    async def write_file(self, path: str, content: str) -> None: ...
+
+    @property
+    def workspace_root(self) -> str: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "garuda-openagent"
+version = "0.1.0"
+description = "Universal provider-agnostic agent harness for terminal and software engineering tasks"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+dependencies = [
+    "litellm>=1.50.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]
+
+[project.scripts]
+garuda = "garuda.interfaces.headless:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["garuda*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/tests/test_phase1.py
+++ b/tests/test_phase1.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from garuda.core.events import EventStore, EventType
+from garuda.core.loop import DefaultAgent
+from garuda.model.protocol import ModelResponse
+from garuda.model.script_model import ScriptModel
+from garuda.tools import default_tools
+from garuda.types import AgentConfig, ToolCall
+from garuda.workspace.local import LocalEnvironment
+
+
+@pytest.mark.asyncio
+async def test_local_environment_execute(tmp_path: Path):
+    env = LocalEnvironment(workspace_root=tmp_path)
+    result = await env.execute("echo hello")
+    assert result.exit_code == 0
+    assert "hello" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_local_environment_read_write(tmp_path: Path):
+    env = LocalEnvironment(workspace_root=tmp_path)
+    await env.write_file("notes.txt", "garuda")
+    content = await env.read_file("notes.txt")
+    assert content == "garuda"
+
+
+@pytest.mark.asyncio
+async def test_default_agent_with_script_model(tmp_path: Path):
+    env = LocalEnvironment(workspace_root=tmp_path)
+    model = ScriptModel(
+        responses=[
+            ModelResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(id="1", name="write_file", arguments={"path": "out.txt", "content": "ok"}),
+                ],
+            ),
+            ModelResponse(content="Task complete. Wrote out.txt.", tool_calls=[]),
+        ]
+    )
+    agent = DefaultAgent()
+    result = await agent.run(
+        task="Write ok to out.txt",
+        model=model,
+        env=env,
+        tools=default_tools(),
+        config=AgentConfig(max_turns=5),
+    )
+    assert result.success
+    assert (tmp_path / "out.txt").read_text() == "ok"
+
+
+def test_event_store_roundtrip(tmp_path: Path):
+    store = EventStore(session_id="test-session")
+    store.append(EventType.SESSION_START, {"task": "demo"})
+    path = tmp_path / "events.jsonl"
+    store.save(path)
+    loaded = EventStore.load(path)
+    assert loaded.session_id == "test-session"
+    assert len(loaded.get_all()) == 1
+    assert loaded.get_all()[0]["type"] == "session_start"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Splits the Garuda RFC into implementable modules and delivers **Phase 1 (Foundation)**.

### Planning
- `docs/MODULES.md` — 33 modules across 6 phases with dependencies, status tracking, and build order

### Phase 1 modules (M1–M7) ✅
| Module | Path |
|--------|------|
| Types | `garuda/types.py` |
| Model layer | `garuda/model/` — `LitellmModel`, `ScriptModel`, bash-block fallback |
| Environment | `garuda/workspace/local.py` |
| Tools | `garuda/tools/` — `bash`, `read_file`, `write_file` |
| Event store | `garuda/core/events.py` |
| Agent loop | `garuda/core/loop.py` — `DefaultAgent` |
| Headless CLI | `garuda/interfaces/headless.py` — `garuda run` |

### Usage
```bash
pip install -e ".[dev]"
python3 -m pytest tests/ -v
garuda run -t "List files in the workspace" --model openai/gpt-4o-mini
```

### Next
Phase 2: context manager, permissions, completion verifier, agent YAML profiles

## Test plan
- [x] `python3 -m pytest tests/ -v` — 4 tests pass
- [ ] Manual run with real API key
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1ca9-7194-776f-aca4-ee48d0cf1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1ca9-7194-776f-aca4-ee48d0cf1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

