### PR TITLE
feat: Agent capabilities v1.1.0 — agent.md, skills, SDK, documents, subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Garuda is a runtime that runs any LLM against real environments using tools (bas
 
 > **Core thesis:** The harness is the product, not the model.
 
-**Version:** 1.0.0 · **Python:** 3.12+ · **License:** MIT
+**Version:** 1.1.0 · **Python:** 3.12+ · **License:** MIT
 
 ---
 
@@ -15,8 +15,11 @@ Garuda is a runtime that runs any LLM against real environments using tools (bas
 | Area | Capabilities |
 |------|--------------|
 | **Models** | Any provider via [LiteLLM](https://github.com/BerriAI/litellm) (`openai/…`, `anthropic/…`, etc.) |
-| **Tools** | `bash`, `read_file`, `write_file`, `apply_patch`, `tmux_exec`, `tmux_capture`, `image_read`, `invoke_subagent`, `task_complete` |
-| **Agents** | Built-in profiles: `build`, `plan`, `explore`, `harbor` — customizable via YAML |
+| **Tools** | `bash`, `read_file`, `write_file`, `apply_patch`, `read_pdf`, `read_spreadsheet`, `tmux_exec`, `tmux_capture`, `image_read`, `invoke_subagent`, `task_complete` + MCP |
+| **Agents** | YAML or **agent.md** profiles: `build`, `plan`, `explore`, `reviewer`, `harbor` |
+| **Skills** | Universal `SKILL.md` format — auto-injected into system prompt |
+| **Subagents** | Main agent spins up isolated subagents via `invoke_subagent` |
+| **SDK** | `garuda.sdk.SoftwareAgent` — OpenHands-style programmatic API |
 | **Workspaces** | `local`, `sandbox`, `tmux`, `docker`, `remote` |
 | **Safety** | Permission modes, completion verifier, optional OS sandbox (bubblewrap) |
 | **Context** | Output shaping, proactive + 3-step summarization |
@@ -37,6 +40,9 @@ cd Garuda-openagent
 
 # Core + dev tools
 pip install -e ".[dev]"
+
+# Add document tools (PDF, Excel)
+pip install -e ".[docs]"
 
 # Add Harbor eval support (optional)
 pip install -e ".[eval]"
@@ -186,7 +192,122 @@ Profiles live in `garuda/agents/defaults/` (or your `--agents-dir`).
 | **build** | Read/write/exec | All core + MCP | Implementation, fixes |
 | **plan** | Read-only | `bash`, `read_file` | Analysis and planning |
 | **explore** | Read-only | `bash`, `read_file` | Fast codebase search (subagent) |
+| **reviewer** | Read-only | `bash`, `read_file` | Code review (subagent, agent.md) |
 | **harbor** | YOLO eval | bash, files, patch, `task_complete` | Harbor benchmarks |
+
+### agent.md (OpenCode-compatible)
+
+Place markdown agents in `.garuda/agents/` or `garuda/agents/defaults/`:
+
+```markdown
+---
+name: my-coder
+description: Full-stack coding agent
+permission_mode: smart
+tools:
+  - bash
+  - read_file
+  - write_file
+  - apply_patch
+  - invoke_subagent
+path_rules:
+  deny:
+    - "**/.env"
+    - "**/secrets/*"
+bash_rules:
+  ask:
+    - "sudo .*"
+---
+
+You are an expert software engineer...
+```
+
+```bash
+garuda run -t "..." --agent my-coder --agents-dir .garuda/agents
+```
+
+### Skills (universal SKILL.md format)
+
+Add skills under `.garuda/skills/` or `skills/`:
+
+```markdown
+---
+name: pdf-processing
+description: Extract and analyze PDF documents
+---
+
+# PDF Processing
+
+When reading PDFs, use read_pdf first. Summarize page by page...
+```
+
+Skills are discovered automatically and injected into the build agent system prompt. Restrict with `skills:` in agent config.
+
+### Subagents
+
+The main `build` agent can delegate to isolated subagents:
+
+```bash
+# Agent calls: invoke_subagent(profile="explore", task="find auth flow")
+# Also available: plan, reviewer
+```
+
+Subagents get their own permissions, event log, and tool set per profile.
+
+### Software Agent SDK
+
+```python
+import asyncio
+from garuda.sdk import SoftwareAgent
+
+async def main():
+    agent = SoftwareAgent(workspace=".", model="openai/gpt-4o-mini", agent="build")
+    result = await agent.run("List Python files and summarize structure")
+    print(result.final_message)
+
+asyncio.run(main())
+```
+
+Multi-turn conversations:
+
+```python
+from garuda.sdk import Conversation
+
+async def main():
+    chat = Conversation(workspace=".", model="openai/gpt-4o-mini")
+    r1 = await chat.run("Find all API routes")
+    r2 = await chat.run("Add tests for the auth routes")
+    await chat.close()
+```
+
+### Custom tools
+
+```python
+from garuda.tools.registry import register_tool
+from garuda.tools.protocol import ToolContext
+from garuda.types import ToolResult
+
+class HelloTool:
+    name = "hello"
+    description = "Say hello"
+    parameters = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+
+    async def execute(self, arguments, env, ctx: ToolContext) -> ToolResult:
+        return ToolResult(tool_call_id="", content=f"Hello {arguments['name']}")
+
+register_tool(HelloTool())
+```
+
+Add tool name to agent profile `tools:` list and optional `tool_rules:`.
+
+### Document files (PDF, Excel)
+
+```bash
+pip install -e ".[docs]"
+garuda run -t "Summarize report.pdf" --agent build
+```
+
+Tools: `read_pdf`, `read_spreadsheet` (`.xlsx`, `.csv`)
 
 ### Custom agent YAML
 
@@ -221,10 +342,12 @@ Connect stdio MCP servers via a YAML config:
 ```yaml
 # .garuda/mcp.yaml
 servers:
-  - name: my-server
+  - name: filesystem
     transport: stdio
     command: npx
     args: ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
+    env:
+      TOKEN: ${MY_TOKEN}   # env var interpolation
 ```
 
 ```bash
@@ -255,6 +378,21 @@ MCP tools are namespaced as `mcp__<server>__<tool>`.
 | `auto` | Auto-approve most tool calls |
 | `readonly` | Deny writes and patches |
 | `yolo` | Allow everything (eval/sandboxed use only) |
+
+Configure per-agent in YAML/agent.md:
+
+```yaml
+permission_mode: smart
+tool_rules:
+  write_file: allow
+  bash: allow
+path_rules:
+  deny: ["**/.env", "**/id_rsa"]
+  ask: ["**/package-lock.json"]
+bash_rules:
+  deny: ["rm -rf /"]
+  ask: ["sudo .*"]
+```
 
 The `task_complete` tool triggers a **completion verifier** that checks summary quality and optional verification commands before accepting task completion.
 
@@ -320,7 +458,7 @@ pytest tests/ -v
 pytest tests/test_phase6.py -v
 ```
 
-**Current test status:** 35 passed, 1 skipped (`docker` not available in some CI environments).
+**Current test status:** 45 passed, 1 skipped (`docker` not available in some CI environments).
 
 ---
 

--- a/garuda/agents/defaults/build.yaml
+++ b/garuda/agents/defaults/build.yaml
@@ -14,14 +14,19 @@ tools:
   - tmux_exec
   - tmux_capture
   - image_read
+  - read_pdf
+  - read_spreadsheet
   - invoke_subagent
   - task_complete
+skills_dirs:
+  - .garuda/skills
+  - skills
 mcp_config_path: null
 tool_rules:
   task_complete: allow
 system_prompt: |
   You are Garuda build agent. Implement tasks using tools.
   Use bash for one-shot commands and tmux_exec for interactive or long-running terminal work.
-  Use invoke_subagent with profile explore or plan for isolated research tasks.
+  Use invoke_subagent with profile explore, plan, or reviewer for isolated research and review tasks.
   Inspect the environment before changing files.
   When fully done, call task_complete with a summary and verification commands.

--- a/garuda/agents/defaults/reviewer.md
+++ b/garuda/agents/defaults/reviewer.md
@@ -1,0 +1,15 @@
+---
+name: reviewer
+description: Read-only code reviewer subagent
+permission_mode: readonly
+mode: standard
+subagent: true
+tools:
+  - bash
+  - read_file
+  - task_complete
+---
+
+You are a code reviewer. Inspect the codebase read-only and provide actionable review feedback.
+Use bash only for read-only commands (grep, find, cat, ls).
+Finish with task_complete summarizing findings and recommendations.

--- a/garuda/agents/frontmatter.py
+++ b/garuda/agents/frontmatter.py
@@ -1,0 +1,18 @@
+"""Parse YAML frontmatter from markdown agent and skill files."""
+
+import re
+from typing import Any
+
+import yaml
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Return (frontmatter dict, body markdown) from a markdown file."""
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}, text.strip()
+    meta = yaml.safe_load(match.group(1)) or {}
+    body = text[match.end() :].strip()
+    return meta, body

--- a/garuda/agents/loader.py
+++ b/garuda/agents/loader.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 
@@ -16,13 +16,22 @@ class AgentProfile:
     tools: list[str] | None = None
     system_prompt: str | None = None
     tool_rules: dict[str, str] | None = None
+    path_rules: dict[str, list[str]] | None = None
+    bash_rules: dict[str, list[str]] | None = None
     max_turns: int = 200
     enable_tmux: bool = True
     marker_polling: bool = True
     enable_three_step_summary: bool = True
+    max_context_tokens: int = 128_000
+    proactive_summarize_threshold: int = 8000
+    max_output_bytes: int = 30_720
     workspace_kind: str = "local"
     docker_image: str = "ubuntu:22.04"
     mcp_config_path: str | None = None
+    skills: list[str] | None = None
+    skills_dirs: list[str] | None = None
+    subagent: bool = False
+    source_path: Path | None = None
 
     def to_agent_config(self) -> AgentConfig:
         return AgentConfig(
@@ -35,9 +44,14 @@ class AgentProfile:
             enable_tmux=self.enable_tmux,
             marker_polling=self.marker_polling,
             enable_three_step_summary=self.enable_three_step_summary,
+            max_context_tokens=self.max_context_tokens,
+            proactive_summarize_threshold=self.proactive_summarize_threshold,
+            max_output_bytes=self.max_output_bytes,
             workspace_kind=self.workspace_kind,
             docker_image=self.docker_image,
             mcp_config_path=self.mcp_config_path,
+            skills=self.skills,
+            skills_dirs=self.skills_dirs,
         )
 
 
@@ -45,34 +59,104 @@ def _defaults_dir() -> Path:
     return Path(resources.files("garuda.agents")) / "defaults"
 
 
+def _profile_names_in_dir(directory: Path) -> set[str]:
+    names: set[str] = set()
+    if not directory.exists():
+        return names
+    for path in directory.glob("*.yaml"):
+        names.add(path.stem)
+    for path in directory.glob("*.md"):
+        names.add(path.stem)
+    for path in directory.glob("agent.md"):
+        names.add(directory.name)
+    for path in directory.glob("**/agent.md"):
+        names.add(path.parent.name)
+    return names
+
+
 def list_profiles(extra_dir: Path | None = None) -> list[str]:
-    names = {path.stem for path in _defaults_dir().glob("*.yaml")}
-    if extra_dir and extra_dir.exists():
-        names.update(path.stem for path in extra_dir.glob("*.yaml"))
+    names = _profile_names_in_dir(_defaults_dir())
+    if extra_dir:
+        names.update(_profile_names_in_dir(extra_dir))
     return sorted(names)
 
 
+def _profile_from_yaml(data: dict, name: str, source: Path | None = None) -> AgentProfile:
+    return AgentProfile(
+        name=data.get("name", name),
+        description=data.get("description", ""),
+        permission_mode=data.get("permission_mode", "smart"),
+        mode=data.get("mode", "standard"),
+        tools=data.get("tools"),
+        system_prompt=data.get("system_prompt"),
+        tool_rules=data.get("tool_rules"),
+        path_rules=data.get("path_rules"),
+        bash_rules=data.get("bash_rules"),
+        max_turns=data.get("max_turns", 200),
+        enable_tmux=data.get("enable_tmux", True),
+        marker_polling=data.get("marker_polling", True),
+        enable_three_step_summary=data.get("enable_three_step_summary", True),
+        max_context_tokens=data.get("max_context_tokens", 128_000),
+        proactive_summarize_threshold=data.get("proactive_summarize_threshold", 8000),
+        max_output_bytes=data.get("max_output_bytes", 30_720),
+        workspace_kind=data.get("workspace_kind", "local"),
+        docker_image=data.get("docker_image", "ubuntu:22.04"),
+        mcp_config_path=data.get("mcp_config_path"),
+        skills=data.get("skills"),
+        skills_dirs=data.get("skills_dirs"),
+        subagent=data.get("subagent", False),
+        source_path=source,
+    )
+
+
 def load_profile(name: str, extra_dir: Path | None = None) -> AgentProfile:
-    candidates = [_defaults_dir() / f"{name}.yaml"]
+    """Load agent profile from YAML or agent.md (OpenCode-compatible)."""
+    from garuda.agents.md_loader import load_agent_md
+
+    candidates: list[Path] = []
     if extra_dir:
-        candidates.insert(0, extra_dir / f"{name}.yaml")
+        candidates.extend(
+            [
+                extra_dir / f"{name}.yaml",
+                extra_dir / f"{name}.md",
+                extra_dir / f"{name}" / "agent.md",
+            ]
+        )
+    candidates.extend(
+        [
+            _defaults_dir() / f"{name}.yaml",
+            _defaults_dir() / f"{name}.md",
+            _defaults_dir() / name / "agent.md",
+        ]
+    )
     for path in candidates:
-        if path.exists():
-            data = yaml.safe_load(path.read_text(encoding="utf-8"))
-            return AgentProfile(
-                name=data.get("name", name),
-                description=data.get("description", ""),
-                permission_mode=data.get("permission_mode", "smart"),
-                mode=data.get("mode", "standard"),
-                tools=data.get("tools"),
-                system_prompt=data.get("system_prompt"),
-                tool_rules=data.get("tool_rules"),
-                max_turns=data.get("max_turns", 200),
-                enable_tmux=data.get("enable_tmux", True),
-                marker_polling=data.get("marker_polling", True),
-                enable_three_step_summary=data.get("enable_three_step_summary", True),
-                workspace_kind=data.get("workspace_kind", "local"),
-                docker_image=data.get("docker_image", "ubuntu:22.04"),
-                mcp_config_path=data.get("mcp_config_path"),
-            )
+        if not path.exists():
+            continue
+        if path.suffix == ".md":
+            return load_agent_md(path)
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return _profile_from_yaml(data, name, source=path)
     raise FileNotFoundError(f"Agent profile not found: {name}")
+
+
+def resolve_system_prompt(profile: AgentProfile, workspace_root: str | Path | None = None) -> str:
+    """Build system prompt with optional skill injection."""
+    from garuda.skills.loader import discover_skills, format_skills_prompt, load_skill
+
+    base = profile.system_prompt or DEFAULT_SYSTEM_PROMPT
+    skill_dirs: list[Path] = []
+    if workspace_root:
+        root = Path(workspace_root)
+        skill_dirs.extend([root / ".garuda" / "skills", root / "skills", root / ".skills"])
+    if profile.skills_dirs:
+        skill_dirs.extend(Path(d) for d in profile.skills_dirs)
+    skill_dirs.extend([Path(".garuda/skills"), Path("skills")])
+
+    discovered = discover_skills(*skill_dirs)
+    if profile.skills:
+        allowed = set(profile.skills)
+        discovered = [s for s in discovered if s.name in allowed]
+    skills_block = format_skills_prompt(discovered)
+    if not skills_block:
+        return base
+    return f"{base}\n\n{skills_block}"

--- a/garuda/agents/md_loader.py
+++ b/garuda/agents/md_loader.py
@@ -1,0 +1,43 @@
+"""Load OpenCode-style agent.md profiles with YAML frontmatter."""
+
+from pathlib import Path
+
+from garuda.agents.frontmatter import parse_frontmatter
+from garuda.agents.loader import AgentProfile
+
+
+def load_agent_md(path: str | Path) -> AgentProfile:
+    """Parse an agent.md file into an AgentProfile."""
+    target = Path(path)
+    meta, body = parse_frontmatter(target.read_text(encoding="utf-8"))
+    tools = meta.get("tools")
+    if isinstance(tools, str):
+        tools = [tools]
+    skills = meta.get("skills")
+    if isinstance(skills, str):
+        skills = [skills]
+    return AgentProfile(
+        name=meta.get("name", target.stem),
+        description=meta.get("description", ""),
+        permission_mode=meta.get("permission_mode", "smart"),
+        mode=meta.get("mode", "standard"),
+        tools=tools,
+        system_prompt=body or meta.get("system_prompt"),
+        tool_rules=meta.get("tool_rules"),
+        path_rules=meta.get("path_rules"),
+        bash_rules=meta.get("bash_rules"),
+        max_turns=meta.get("max_turns", 200),
+        enable_tmux=meta.get("enable_tmux", True),
+        marker_polling=meta.get("marker_polling", True),
+        enable_three_step_summary=meta.get("enable_three_step_summary", True),
+        max_context_tokens=meta.get("max_context_tokens", 128_000),
+        proactive_summarize_threshold=meta.get("proactive_summarize_threshold", 8000),
+        max_output_bytes=meta.get("max_output_bytes", 30_720),
+        workspace_kind=meta.get("workspace_kind", "local"),
+        docker_image=meta.get("docker_image", "ubuntu:22.04"),
+        mcp_config_path=meta.get("mcp_config_path"),
+        skills=skills,
+        skills_dirs=meta.get("skills_dirs"),
+        subagent=meta.get("subagent", False),
+        source_path=target,
+    )

--- a/garuda/context/manager.py
+++ b/garuda/context/manager.py
@@ -15,6 +15,7 @@ class ContextManager:
         max_context_tokens: int = 128_000,
         enable_three_step_summary: bool = True,
         task: str = "",
+        keep_recent_turns: int = 12,
     ):
         self._model = model
         self._max_output_bytes = max_output_bytes
@@ -22,6 +23,7 @@ class ContextManager:
         self._max_context_tokens = max_context_tokens
         self._enable_three_step_summary = enable_three_step_summary
         self._task = task
+        self._keep_recent_turns = keep_recent_turns
         self._messages: list[Message] = []
 
     def seed(self, messages: list[Message]) -> None:
@@ -39,7 +41,7 @@ class ContextManager:
     def shape_observation(self, output: str) -> str:
         return shape_observation(output, self._max_output_bytes)
 
-    def fork(self) -> "ContextManager":
+    def fork(self, *, include_history: bool = True) -> "ContextManager":
         forked = ContextManager(
             model=self._model,
             max_output_bytes=self._max_output_bytes,
@@ -47,14 +49,20 @@ class ContextManager:
             max_context_tokens=self._max_context_tokens,
             enable_three_step_summary=self._enable_three_step_summary,
             task=self._task,
+            keep_recent_turns=self._keep_recent_turns,
         )
-        forked._messages = deepcopy(self._messages)
+        if include_history:
+            forked._messages = deepcopy(self._messages)
         return forked
 
+    def _estimate_tokens(self) -> int:
+        return self._model.count_tokens(self._messages)
+
     async def maybe_summarize(self) -> bool:
-        used = self._model.count_tokens(self._messages)
+        used = self._estimate_tokens()
         free = self._max_context_tokens - used
-        if free >= self._proactive_threshold:
+        turn_pairs = sum(1 for m in self._messages if m.role == Role.ASSISTANT)
+        if free >= self._proactive_threshold and turn_pairs < self._keep_recent_turns * 2:
             return False
 
         if self._enable_three_step_summary:
@@ -64,6 +72,7 @@ class ContextManager:
 
         system = self._messages[0] if self._messages and self._messages[0].role == Role.SYSTEM else None
         task = next((m for m in self._messages if m.role == Role.USER), None)
+        recent = self._recent_messages()
         rebuilt: list[Message] = []
         if system:
             rebuilt.append(system)
@@ -75,8 +84,28 @@ class ContextManager:
                 content=f"Conversation summary (context compacted):\n{summary}",
             )
         )
+        rebuilt.extend(recent)
         self._messages = rebuilt
         return True
+
+    def _recent_messages(self) -> list[Message]:
+        if self._keep_recent_turns <= 0:
+            return []
+        collected: list[Message] = []
+        turns = 0
+        skipped_seed_user = False
+        for message in reversed(self._messages):
+            if message.role == Role.SYSTEM:
+                continue
+            if message.role == Role.USER and not skipped_seed_user:
+                skipped_seed_user = True
+                continue
+            if message.role == Role.ASSISTANT:
+                turns += 1
+            collected.append(message)
+            if turns >= self._keep_recent_turns:
+                break
+        return list(reversed(collected))
 
     def _compact_summary(self) -> str:
         lines: list[str] = []

--- a/garuda/core/loop.py
+++ b/garuda/core/loop.py
@@ -51,6 +51,7 @@ class DefaultAgent:
         permissions: PermissionEngine | None = None,
         hooks: HookRegistry | None = None,
         subagent_runner=None,
+        agents_dir=None,
     ) -> AgentResult:
         config = config or AgentConfig()
         events = events or EventStore()
@@ -72,6 +73,7 @@ class DefaultAgent:
             model=model,
             max_output_bytes=config.max_output_bytes,
             proactive_threshold=config.proactive_summarize_threshold,
+            max_context_tokens=config.max_context_tokens,
             enable_three_step_summary=config.enable_three_step_summary,
             task=task,
         )
@@ -89,8 +91,10 @@ class DefaultAgent:
             subagent_runner = SubagentRunner(
                 model=model,
                 env=env,
-                permissions=permissions,
                 events=events,
+                agents_dir=agents_dir,
+                skills_dirs=config.skills_dirs,
+                workspace_root=getattr(env, "workspace_root", None),
             )
 
         ctx = ToolContext(

--- a/garuda/core/permissions.py
+++ b/garuda/core/permissions.py
@@ -1,5 +1,7 @@
+import fnmatch
 import re
 from enum import Enum
+from pathlib import Path
 from typing import Awaitable, Callable
 
 ApprovalHandler = Callable[[str], Awaitable[bool]]
@@ -33,11 +35,19 @@ class PermissionEngine:
         self,
         mode: str = "smart",
         tool_rules: dict[str, str] | None = None,
+        path_rules: dict[str, list[str]] | None = None,
+        bash_rules: dict[str, list[str]] | None = None,
         approval_handler: ApprovalHandler | None = None,
     ):
         self._mode = mode
         self._tool_rules = tool_rules or {}
+        self._path_rules = path_rules or {}
+        self._bash_rules = bash_rules or {}
         self._approval_handler = approval_handler
+        self._deny_paths = self._path_rules.get("deny", [])
+        self._ask_paths = self._path_rules.get("ask", [])
+        self._deny_bash = [re.compile(p) for p in self._bash_rules.get("deny", [])]
+        self._ask_bash = [re.compile(p) for p in self._bash_rules.get("ask", [])]
 
     @property
     def mode(self) -> str:
@@ -56,9 +66,27 @@ class PermissionEngine:
             return PermissionDecision.ALLOW
         return PermissionDecision.ALLOW
 
+    def _path_matches(self, path: str, pattern: str) -> bool:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+        normalized = pattern.removeprefix("**/")
+        return fnmatch.fnmatch(path, normalized) or Path(path).name == normalized
+
+    def _match_path_rules(self, path: str) -> PermissionDecision | None:
+        for pattern in self._deny_paths:
+            if self._path_matches(path, pattern):
+                return PermissionDecision.DENY
+        for pattern in self._ask_paths:
+            if self._path_matches(path, pattern):
+                return PermissionDecision.ASK
+        return None
+
     def check_path(self, path: str, operation: str) -> PermissionDecision:
         if self._mode in ("auto", "yolo"):
             return PermissionDecision.ALLOW
+        rule = self._match_path_rules(path)
+        if rule:
+            return rule
         if self._mode == "readonly" and operation in ("write", "patch"):
             return PermissionDecision.DENY
         return PermissionDecision.ALLOW
@@ -68,10 +96,10 @@ class PermissionEngine:
             return PermissionDecision.ALLOW
         if self._mode == "readonly":
             return PermissionDecision.DENY
-        for pattern in DENY_COMMAND_PATTERNS:
+        for pattern in self._deny_bash + DENY_COMMAND_PATTERNS:
             if pattern.search(command):
                 return PermissionDecision.DENY
-        for pattern in ASK_COMMAND_PATTERNS:
+        for pattern in self._ask_bash + ASK_COMMAND_PATTERNS:
             if pattern.search(command):
                 return PermissionDecision.ASK
         return PermissionDecision.ALLOW
@@ -83,10 +111,8 @@ class PermissionEngine:
 
         if tool_name == "bash":
             decision = self.check_command(arguments.get("command", ""))
-        elif tool_name == "write_file":
-            decision = self.check_path(arguments.get("path", ""), "write")
-        elif tool_name == "apply_patch":
-            decision = self.check_path(arguments.get("path", ""), "patch")
+        elif tool_name in ("write_file", "apply_patch", "read_file", "read_pdf", "read_spreadsheet"):
+            decision = self.check_path(arguments.get("path", ""), "write" if tool_name == "write_file" else "read")
 
         if decision == PermissionDecision.DENY:
             return False, f"Permission denied for {tool_name}"

--- a/garuda/core/subagent.py
+++ b/garuda/core/subagent.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from garuda.agents.loader import load_profile
-from garuda.core.events import EventStore
+from garuda.core.events import EventStore, EventType
 from garuda.core.permissions import PermissionEngine
 from garuda.model.protocol import Model
-from garuda.tools import tools_for_names
-from garuda.types import AgentResult
+from garuda.tools import build_toolkit
+from garuda.types import AgentResult, Message, Role
 from garuda.workspace.protocol import Environment
 
 
@@ -14,29 +14,60 @@ from garuda.workspace.protocol import Environment
 class SubagentRunner:
     model: Model
     env: Environment
-    permissions: PermissionEngine
     events: EventStore
     agents_dir: Path | None = None
+    skills_dirs: list[str] | None = None
+    workspace_root: str | None = None
     max_turns: int = 50
+    fork_parent_context: bool = False
+    parent_messages: list[Message] | None = None
 
     async def run(self, profile_name: str, task: str) -> AgentResult:
+        from garuda.agents.loader import resolve_system_prompt
         from garuda.core.loop import DefaultAgent
 
         profile = load_profile(profile_name, extra_dir=self.agents_dir)
         config = profile.to_agent_config()
         config.max_turns = min(config.max_turns, self.max_turns)
         config.enable_three_step_summary = False
-        tools = tools_for_names(profile.tools)
+        config.system_prompt = resolve_system_prompt(profile, self.workspace_root)
+
+        permissions = PermissionEngine(
+            mode=profile.permission_mode,
+            tool_rules=profile.tool_rules,
+            path_rules=profile.path_rules,
+            bash_rules=profile.bash_rules,
+        )
+        tools, mcp_manager = await build_toolkit(
+            profile.tools,
+            profile.mcp_config_path,
+        )
+        sub_events = EventStore()
         agent = DefaultAgent(profile_name=profile.name)
-        return await agent.run(
+
+        result = await agent.run(
             task=task,
             model=self.model,
             env=self.env,
             tools=tools,
             config=config,
-            events=self.events,
-            permissions=self.permissions,
+            events=sub_events,
+            permissions=permissions,
         )
+        if mcp_manager is not None:
+            await mcp_manager.close()
+
+        self.events.append(
+            EventType.USER_MESSAGE,
+            {
+                "content": f"[subagent:{profile_name}] {result.final_message}",
+                "subagent": profile_name,
+                "success": result.success,
+            },
+        )
+        result.metadata["subagent_session_id"] = sub_events.session_id
+        result.metadata["subagent_profile"] = profile_name
+        return result
 
 
 def format_subagent_summary(profile_name: str, result: AgentResult) -> str:

--- a/garuda/interfaces/main.py
+++ b/garuda/interfaces/main.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from garuda.agents.loader import load_profile
+from garuda.agents.loader import load_profile, resolve_system_prompt
 from garuda.core.events import EventStore
 from garuda.core.permissions import PermissionEngine
 from garuda.core.rigorous import create_agent
@@ -130,13 +130,20 @@ async def run_task(args) -> int:
     config.workspace_kind = args.workspace_kind
     config.docker_image = args.docker_image
     config.docker_host = args.docker_host
+    config.system_prompt = resolve_system_prompt(profile, args.workspace)
     mcp_path = args.mcp_config or config.mcp_config_path
 
     model = LitellmModel(model_name=args.model)
-    permissions = PermissionEngine(mode=config.permission_mode, tool_rules=profile.tool_rules)
+    permissions = PermissionEngine(
+        mode=config.permission_mode,
+        tool_rules=profile.tool_rules,
+        path_rules=profile.path_rules,
+        bash_rules=profile.bash_rules,
+    )
     agent = create_agent(profile.name, mode=config.mode)
     events = EventStore()
     tools, mcp_manager = await build_toolkit(profile.tools, mcp_path)
+    agents_dir = Path(args.agents_dir) if args.agents_dir else None
 
     result = await run_agent_task(
         task=task,
@@ -152,6 +159,7 @@ async def run_task(args) -> int:
         docker_image=args.docker_image,
         docker_host=args.docker_host,
         mcp_manager=mcp_manager,
+        agents_dir=agents_dir,
     )
 
     if args.trajectory:

--- a/garuda/interfaces/runner.py
+++ b/garuda/interfaces/runner.py
@@ -54,6 +54,7 @@ async def run_agent_task(
     docker_host: str | None = None,
     hooks: HookRegistry | None = None,
     mcp_manager=None,
+    agents_dir=None,
 ) -> AgentResult:
     env, handle = await resolve_environment(
         workspace_kind, workspace, docker_image, docker_host=docker_host
@@ -68,6 +69,7 @@ async def run_agent_task(
             events=events,
             permissions=permissions,
             hooks=hooks,
+            agents_dir=agents_dir,
         )
     finally:
         await cleanup_workspace(handle)

--- a/garuda/mcp/config.py
+++ b/garuda/mcp/config.py
@@ -1,8 +1,20 @@
+import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+_ENV_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _interpolate(value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        return os.environ.get(key, "")
+
+    return _ENV_PATTERN.sub(replace, value)
 
 
 @dataclass
@@ -12,6 +24,7 @@ class McpServerConfig:
     command: str = ""
     args: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
+    url: str | None = None
 
 
 def load_mcp_config(path: str | Path) -> list[McpServerConfig]:
@@ -19,13 +32,17 @@ def load_mcp_config(path: str | Path) -> list[McpServerConfig]:
     servers = data.get("servers", [])
     configs: list[McpServerConfig] = []
     for entry in servers:
+        command = _interpolate(entry.get("command", ""))
+        args = [_interpolate(str(a)) for a in entry.get("args", [])]
+        env = {k: _interpolate(str(v)) for k, v in entry.get("env", {}).items()}
         configs.append(
             McpServerConfig(
                 name=entry["name"],
                 transport=entry.get("transport", "stdio"),
-                command=entry["command"],
-                args=entry.get("args", []),
-                env=entry.get("env", {}),
+                command=command,
+                args=args,
+                env=env,
+                url=entry.get("url"),
             )
         )
     return configs

--- a/garuda/sdk/__init__.py
+++ b/garuda/sdk/__init__.py
@@ -1,0 +1,6 @@
+"""OpenHands-style Software Agent SDK for Garuda."""
+
+from garuda.sdk.conversation import Conversation
+from garuda.sdk.software_agent import SoftwareAgent
+
+__all__ = ["Conversation", "SoftwareAgent"]

--- a/garuda/sdk/conversation.py
+++ b/garuda/sdk/conversation.py
@@ -1,0 +1,77 @@
+"""Stateful conversation wrapper around Garuda agent runs."""
+
+from pathlib import Path
+
+from garuda.agents.loader import load_profile, resolve_system_prompt
+from garuda.core.events import EventStore
+from garuda.core.loop import DefaultAgent
+from garuda.core.permissions import PermissionEngine
+from garuda.core.rigorous import create_agent
+from garuda.model.litellm_model import LitellmModel
+from garuda.tools import build_toolkit
+from garuda.types import AgentConfig, AgentResult
+from garuda.workspace.local import LocalEnvironment
+
+
+class Conversation:
+    """Multi-turn Garuda session with shared event history."""
+
+    def __init__(
+        self,
+        workspace: str | Path = ".",
+        model: str = "openai/gpt-4o-mini",
+        agent: str = "build",
+        agents_dir: str | Path | None = None,
+        mcp_config: str | None = None,
+        mode: str = "standard",
+    ):
+        self._workspace = str(workspace)
+        self._model = LitellmModel(model_name=model)
+        self._agent_name = agent
+        self._agents_dir = Path(agents_dir) if agents_dir else None
+        self._mcp_config = mcp_config
+        self._mode = mode
+        self._events = EventStore()
+        self._env = LocalEnvironment(workspace_root=self._workspace)
+        self._tools = None
+        self._mcp_manager = None
+        self._profile = load_profile(agent, extra_dir=self._agents_dir)
+
+    async def _ensure_tools(self) -> None:
+        if self._tools is None:
+            config = self._profile.to_agent_config()
+            mcp_path = self._mcp_config or config.mcp_config_path
+            self._tools, self._mcp_manager = await build_toolkit(self._profile.tools, mcp_path)
+
+    async def run(self, task: str) -> AgentResult:
+        """Run a task in this conversation."""
+        await self._ensure_tools()
+        config = self._profile.to_agent_config()
+        config.mode = self._mode
+        config.system_prompt = resolve_system_prompt(self._profile, self._workspace)
+        permissions = PermissionEngine(
+            mode=config.permission_mode,
+            tool_rules=self._profile.tool_rules,
+            path_rules=self._profile.path_rules,
+            bash_rules=self._profile.bash_rules,
+        )
+        agent = create_agent(self._profile.name, mode=self._mode)
+        return await agent.run(
+            task=task,
+            model=self._model,
+            env=self._env,
+            tools=self._tools or [],
+            config=config,
+            events=self._events,
+            permissions=permissions,
+            agents_dir=self._agents_dir,
+        )
+
+    async def close(self) -> None:
+        if self._mcp_manager is not None:
+            await self._mcp_manager.close()
+            self._mcp_manager = None
+
+    @property
+    def events(self) -> EventStore:
+        return self._events

--- a/garuda/sdk/software_agent.py
+++ b/garuda/sdk/software_agent.py
@@ -1,0 +1,94 @@
+"""High-level Software Agent SDK entry point."""
+
+from pathlib import Path
+
+from garuda.agents.loader import load_profile, resolve_system_prompt
+from garuda.core.events import EventStore
+from garuda.core.permissions import PermissionEngine
+from garuda.core.rigorous import create_agent
+from garuda.interfaces.runner import run_agent_task
+from garuda.model.litellm_model import LitellmModel
+from garuda.tools import build_toolkit, register_tool
+from garuda.tools.protocol import Tool
+from garuda.types import AgentResult
+
+
+class SoftwareAgent:
+    """OpenHands-style SDK for building on top of Garuda."""
+
+    def __init__(
+        self,
+        workspace: str | Path = ".",
+        model: str = "openai/gpt-4o-mini",
+        agent: str = "build",
+        agents_dir: str | Path | None = None,
+        mcp_config: str | None = None,
+        workspace_kind: str = "local",
+        docker_image: str = "ubuntu:22.04",
+        docker_host: str | None = None,
+        mode: str = "standard",
+    ):
+        self.workspace = str(workspace)
+        self.model_name = model
+        self.agent_name = agent
+        self.agents_dir = Path(agents_dir) if agents_dir else None
+        self.mcp_config = mcp_config
+        self.workspace_kind = workspace_kind
+        self.docker_image = docker_image
+        self.docker_host = docker_host
+        self.mode = mode
+
+    @staticmethod
+    def register_tool(tool: Tool, *, replace: bool = False) -> None:
+        """Register a custom tool available to all SDK runs."""
+        register_tool(tool, replace=replace)
+
+    async def run(self, task: str, *, events: EventStore | None = None) -> AgentResult:
+        """Execute a task and return the agent result."""
+        profile = load_profile(self.agent_name, extra_dir=self.agents_dir)
+        config = profile.to_agent_config()
+        config.mode = self.mode
+        config.workspace_kind = self.workspace_kind
+        config.docker_image = self.docker_image
+        config.docker_host = self.docker_host
+        config.system_prompt = resolve_system_prompt(profile, self.workspace)
+        mcp_path = self.mcp_config or config.mcp_config_path
+
+        model = LitellmModel(model_name=self.model_name)
+        permissions = PermissionEngine(
+            mode=config.permission_mode,
+            tool_rules=profile.tool_rules,
+            path_rules=profile.path_rules,
+            bash_rules=profile.bash_rules,
+        )
+        agent = create_agent(profile.name, mode=self.mode)
+        events = events or EventStore()
+        tools, mcp_manager = await build_toolkit(profile.tools, mcp_path)
+
+        return await run_agent_task(
+            task=task,
+            model=model,
+            agent=agent,
+            tools=tools,
+            config=config,
+            permissions=permissions,
+            workspace=self.workspace,
+            events=events,
+            workspace_kind=self.workspace_kind,
+            docker_image=self.docker_image,
+            docker_host=self.docker_host,
+            mcp_manager=mcp_manager,
+            agents_dir=self.agents_dir,
+        )
+
+    def conversation(self) -> "Conversation":
+        from garuda.sdk.conversation import Conversation
+
+        return Conversation(
+            workspace=self.workspace,
+            model=self.model_name,
+            agent=self.agent_name,
+            agents_dir=self.agents_dir,
+            mcp_config=self.mcp_config,
+            mode=self.mode,
+        )

--- a/garuda/skills/__init__.py
+++ b/garuda/skills/__init__.py
@@ -1,0 +1,3 @@
+from garuda.skills.loader import Skill, discover_skills, format_skills_prompt, load_skill
+
+__all__ = ["Skill", "discover_skills", "format_skills_prompt", "load_skill"]

--- a/garuda/skills/loader.py
+++ b/garuda/skills/loader.py
@@ -1,0 +1,58 @@
+"""Universal SKILL.md loader (Anthropic / OpenCode compatible format)."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from garuda.agents.frontmatter import parse_frontmatter
+
+
+@dataclass
+class Skill:
+    name: str
+    description: str
+    body: str
+    path: Path | None = None
+
+    def to_prompt_block(self) -> str:
+        return f"### Skill: {self.name}\n{self.description}\n\n{self.body}"
+
+
+def load_skill(path: str | Path) -> Skill:
+    """Load a single SKILL.md or skill markdown file."""
+    target = Path(path)
+    meta, body = parse_frontmatter(target.read_text(encoding="utf-8"))
+    return Skill(
+        name=meta.get("name", target.parent.name),
+        description=meta.get("description", ""),
+        body=body,
+        path=target,
+    )
+
+
+def discover_skills(*directories: str | Path) -> list[Skill]:
+    """Discover SKILL.md files under standard locations."""
+    skills: list[Skill] = []
+    seen: set[str] = set()
+    for directory in directories:
+        root = Path(directory)
+        if not root.exists():
+            continue
+        patterns = ["SKILL.md", "skill.md", "**/SKILL.md", "**/skill.md"]
+        for pattern in patterns:
+            for path in root.glob(pattern):
+                if not path.is_file():
+                    continue
+                skill = load_skill(path)
+                if skill.name in seen:
+                    continue
+                seen.add(skill.name)
+                skills.append(skill)
+    return sorted(skills, key=lambda s: s.name)
+
+
+def format_skills_prompt(skills: list[Skill]) -> str:
+    """Format loaded skills for injection into the system prompt."""
+    if not skills:
+        return ""
+    blocks = [skill.to_prompt_block() for skill in skills]
+    return "## Available Skills\n\n" + "\n\n---\n\n".join(blocks)

--- a/garuda/tools/__init__.py
+++ b/garuda/tools/__init__.py
@@ -1,9 +1,11 @@
 from garuda.mcp.client import McpClientManager
 from garuda.tools.bash import BashTool
+from garuda.tools.documents import ReadPdfTool, ReadSpreadsheetTool
 from garuda.tools.files import ReadFileTool, WriteFileTool
 from garuda.tools.image_read import ImageReadTool
 from garuda.tools.patch import ApplyPatchTool
 from garuda.tools.protocol import Tool
+from garuda.tools.registry import list_tool_names, register_tool, tools_for_names
 from garuda.tools.subagent import InvokeSubagentTool
 from garuda.tools.task_complete import TaskCompleteTool
 from garuda.tools.tmux import TmuxCaptureTool, TmuxExecTool
@@ -15,26 +17,38 @@ __all__ = [
     "InvokeSubagentTool",
     "McpClientManager",
     "ReadFileTool",
+    "ReadPdfTool",
+    "ReadSpreadsheetTool",
     "TaskCompleteTool",
     "TmuxCaptureTool",
     "TmuxExecTool",
     "WriteFileTool",
     "build_toolkit",
     "default_tools",
+    "list_tool_names",
+    "register_tool",
     "tools_for_names",
 ]
 
-_TOOL_REGISTRY: dict[str, Tool] = {
-    "bash": BashTool(),
-    "read_file": ReadFileTool(),
-    "write_file": WriteFileTool(),
-    "apply_patch": ApplyPatchTool(),
-    "task_complete": TaskCompleteTool(),
-    "tmux_exec": TmuxExecTool(),
-    "tmux_capture": TmuxCaptureTool(),
-    "image_read": ImageReadTool(),
-    "invoke_subagent": InvokeSubagentTool(),
-}
+
+def _bootstrap_registry() -> None:
+    for tool in [
+        BashTool(),
+        ReadFileTool(),
+        WriteFileTool(),
+        ApplyPatchTool(),
+        TaskCompleteTool(),
+        TmuxExecTool(),
+        TmuxCaptureTool(),
+        ImageReadTool(),
+        ReadPdfTool(),
+        ReadSpreadsheetTool(),
+        InvokeSubagentTool(),
+    ]:
+        register_tool(tool, replace=True)
+
+
+_bootstrap_registry()
 
 
 def default_tools() -> list[Tool]:
@@ -47,16 +61,12 @@ def default_tools() -> list[Tool]:
             "tmux_exec",
             "tmux_capture",
             "image_read",
+            "read_pdf",
+            "read_spreadsheet",
             "invoke_subagent",
             "task_complete",
         ]
     )
-
-
-def tools_for_names(names: list[str] | None) -> list[Tool]:
-    if names is None:
-        return list(_TOOL_REGISTRY.values())
-    return [_TOOL_REGISTRY[name] for name in names if name in _TOOL_REGISTRY]
 
 
 async def build_toolkit(

--- a/garuda/tools/documents.py
+++ b/garuda/tools/documents.py
@@ -1,0 +1,117 @@
+"""Read PDF and spreadsheet files from the workspace."""
+
+import base64
+import shlex
+from pathlib import Path
+
+from garuda.tools.protocol import ToolContext
+from garuda.types import ToolResult
+from garuda.workspace.protocol import Environment
+
+
+async def _read_file_bytes(env: Environment, path: str) -> bytes:
+    resolved = path if path.startswith("/") else f"{env.workspace_root.rstrip('/')}/{path}"
+    result = await env.execute(f"base64 -w0 {shlex.quote(resolved)} 2>/dev/null || base64 {shlex.quote(resolved)}")
+    if result.exit_code != 0:
+        raise FileNotFoundError(result.stderr or f"Cannot read binary file: {path}")
+    return base64.b64decode(result.stdout.strip())
+
+
+def _read_pdf_bytes(data: bytes, max_chars: int = 50_000) -> str:
+    from io import BytesIO
+
+    from pypdf import PdfReader
+
+    reader = PdfReader(BytesIO(data))
+    parts: list[str] = []
+    for index, page in enumerate(reader.pages):
+        text = page.extract_text() or ""
+        if text.strip():
+            parts.append(f"--- Page {index + 1} ---\n{text}")
+    content = "\n\n".join(parts)
+    if len(content) > max_chars:
+        content = content[:max_chars] + "\n...[truncated]"
+    return content or "(No extractable text in PDF)"
+
+
+def _read_xlsx_bytes(data: bytes, max_rows: int = 200) -> str:
+    from io import BytesIO
+
+    from openpyxl import load_workbook
+
+    workbook = load_workbook(BytesIO(data), read_only=True, data_only=True)
+    parts: list[str] = []
+    for sheet_name in workbook.sheetnames:
+        sheet = workbook[sheet_name]
+        rows: list[str] = []
+        for row_index, row in enumerate(sheet.iter_rows(values_only=True)):
+            if row_index >= max_rows:
+                rows.append("...[truncated rows]")
+                break
+            cells = ["" if cell is None else str(cell) for cell in row]
+            if any(cells):
+                rows.append("\t".join(cells))
+        parts.append(f"## Sheet: {sheet_name}\n" + "\n".join(rows))
+    workbook.close()
+    return "\n\n".join(parts)
+
+
+class ReadPdfTool:
+    name = "read_pdf"
+    description = "Extract text content from a PDF file in the workspace."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the PDF file"},
+            "max_chars": {"type": "integer", "description": "Max characters to return", "default": 50000},
+        },
+        "required": ["path"],
+    }
+
+    async def execute(self, arguments: dict, env: Environment, ctx: ToolContext) -> ToolResult:
+        path = arguments["path"]
+        max_chars = int(arguments.get("max_chars", 50_000))
+        try:
+            import pypdf  # noqa: F401
+        except ImportError:
+            return ToolResult(
+                tool_call_id="",
+                content="read_pdf requires: pip install 'garuda-openagent[docs]'",
+                is_error=True,
+            )
+        data = await _read_file_bytes(env, path)
+        content = _read_pdf_bytes(data, max_chars=max_chars)
+        return ToolResult(tool_call_id="", content=content)
+
+
+class ReadSpreadsheetTool:
+    name = "read_spreadsheet"
+    description = "Read an Excel (.xlsx) or CSV spreadsheet from the workspace as tab-separated text."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to .xlsx or .csv file"},
+            "max_rows": {"type": "integer", "description": "Max rows per sheet", "default": 200},
+        },
+        "required": ["path"],
+    }
+
+    async def execute(self, arguments: dict, env: Environment, ctx: ToolContext) -> ToolResult:
+        path = arguments["path"]
+        max_rows = int(arguments.get("max_rows", 200))
+        suffix = Path(path).suffix.lower()
+        if suffix == ".csv":
+            content = await env.read_file(path)
+            lines = content.splitlines()[:max_rows]
+            return ToolResult(tool_call_id="", content="\n".join(lines))
+        try:
+            import openpyxl  # noqa: F401
+        except ImportError:
+            return ToolResult(
+                tool_call_id="",
+                content="read_spreadsheet requires: pip install 'garuda-openagent[docs]'",
+                is_error=True,
+            )
+        data = await _read_file_bytes(env, path)
+        content = _read_xlsx_bytes(data, max_rows=max_rows)
+        return ToolResult(tool_call_id="", content=content)

--- a/garuda/tools/registry.py
+++ b/garuda/tools/registry.py
@@ -1,0 +1,36 @@
+"""Dynamic tool registry for built-in and plugin tools."""
+
+from garuda.tools.protocol import Tool
+
+_REGISTRY: dict[str, Tool] = {}
+
+
+def register_tool(tool: Tool, *, replace: bool = False) -> None:
+    """Register a tool by name. Set replace=True to override built-ins."""
+    if tool.name in _REGISTRY and not replace:
+        raise ValueError(f"Tool already registered: {tool.name}")
+    _REGISTRY[tool.name] = tool
+
+
+def get_tool(name: str) -> Tool | None:
+    return _REGISTRY.get(name)
+
+
+def list_tool_names() -> list[str]:
+    return sorted(_REGISTRY.keys())
+
+
+def tools_for_names(names: list[str] | None) -> list[Tool]:
+    if names is None:
+        return list(_REGISTRY.values())
+    tools: list[Tool] = []
+    for name in names:
+        if name in _REGISTRY:
+            tools.append(_REGISTRY[name])
+        elif name.startswith("mcp__"):
+            continue
+    return tools
+
+
+def clear_registry() -> None:
+    _REGISTRY.clear()

--- a/garuda/types.py
+++ b/garuda/types.py
@@ -60,6 +60,9 @@ class AgentConfig:
     mcp_config_path: str | None = None
     system_prompt: str | None = None
     allowed_tools: list[str] | None = None
+    max_context_tokens: int = 128_000
+    skills: list[str] | None = None
+    skills_dirs: list[str] | None = None
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garuda-openagent"
-version = "1.0.0"
+version = "1.1.0"
 description = "Universal provider-agnostic agent harness for terminal and software engineering tasks"
 readme = "README.md"
 license = { text = "MIT" }
@@ -22,6 +22,10 @@ dev = [
 ]
 eval = [
     "harbor>=0.16.0",
+]
+docs = [
+    "pypdf>=4.0",
+    "openpyxl>=3.1",
 ]
 server = []
 

--- a/tests/test_phase3.py
+++ b/tests/test_phase3.py
@@ -102,7 +102,9 @@ async def test_context_manager_three_step_summary():
     )
     changed = await manager.maybe_summarize()
     assert changed
-    assert len(manager.get_messages()) <= 3
+    messages = manager.get_messages()
+    assert len(messages) <= 4
+    assert any("Conversation summary" in m.content for m in messages)
 
 
 @pytest.mark.asyncio

--- a/tests/test_phase4.py
+++ b/tests/test_phase4.py
@@ -151,7 +151,6 @@ async def test_invoke_subagent_tool(tmp_path):
     runner = SubagentRunner(
         model=explore_model,
         env=env,
-        permissions=PermissionEngine(mode="auto"),
         events=events,
     )
     agent = DefaultAgent()

--- a/tests/test_phase7.py
+++ b/tests/test_phase7.py
@@ -1,0 +1,136 @@
+"""Tests for agent capabilities: agent.md, skills, SDK, documents, permissions."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from garuda.agents.frontmatter import parse_frontmatter
+from garuda.agents.loader import list_profiles, load_profile, resolve_system_prompt
+from garuda.agents.md_loader import load_agent_md
+from garuda.core.permissions import PermissionEngine
+from garuda.mcp.config import load_mcp_config
+from garuda.skills.loader import discover_skills, format_skills_prompt, load_skill
+from garuda.tools.registry import list_tool_names, register_tool
+from garuda.tools.task_complete import TaskCompleteTool
+
+
+def test_parse_frontmatter():
+    text = "---\nname: demo\ndescription: test\n---\n\nBody here"
+    meta, body = parse_frontmatter(text)
+    assert meta["name"] == "demo"
+    assert body == "Body here"
+
+
+def test_load_reviewer_agent_md():
+    profile = load_profile("reviewer")
+    assert profile.permission_mode == "readonly"
+    assert "read_file" in (profile.tools or [])
+
+
+def test_list_profiles_includes_reviewer():
+    assert "reviewer" in list_profiles()
+
+
+def test_skill_loader(tmp_path):
+    skill_dir = tmp_path / "pdf-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: pdf-processing\ndescription: Work with PDFs\n---\n\nExtract text carefully.\n",
+        encoding="utf-8",
+    )
+    skills = discover_skills(skill_dir)
+    assert len(skills) == 1
+    assert skills[0].name == "pdf-processing"
+    prompt = format_skills_prompt(skills)
+    assert "pdf-processing" in prompt
+
+
+def test_resolve_system_prompt_with_skills(tmp_path):
+    skill_dir = tmp_path / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo-skill\ndescription: Demo\n---\n\nSkill body.",
+        encoding="utf-8",
+    )
+    profile = load_profile("build")
+    profile.skills = ["demo-skill"]
+    profile.skills_dirs = [str(tmp_path / "skills")]
+    prompt = resolve_system_prompt(profile, tmp_path)
+    assert "demo-skill" in prompt
+
+
+def test_path_permission_rules():
+    engine = PermissionEngine(
+        mode="smart",
+        path_rules={"deny": ["**/.env", "**/secrets/*"]},
+    )
+    allowed, _ = __import__("asyncio").run(engine.evaluate_tool_call("read_file", {"path": ".env"}))
+    assert not allowed
+
+
+def test_mcp_env_interpolation(tmp_path, monkeypatch):
+    monkeypatch.setenv("MY_TOKEN", "secret123")
+    config = tmp_path / "mcp.yaml"
+    config.write_text(
+        "servers:\n  - name: echo\n    transport: stdio\n    command: echo\n    args: []\n    env:\n      TOKEN: ${MY_TOKEN}\n",
+        encoding="utf-8",
+    )
+    servers = load_mcp_config(config)
+    assert servers[0].env["TOKEN"] == "secret123"
+
+
+def test_tool_registry_register():
+    tool = TaskCompleteTool()
+    register_tool(tool, replace=True)
+    assert "task_complete" in list_tool_names()
+
+
+def test_document_tools_registered():
+    names = list_tool_names()
+    assert "read_pdf" in names
+    assert "read_spreadsheet" in names
+
+
+@pytest.mark.asyncio
+async def test_software_agent_sdk(tmp_path):
+    from garuda.core.loop import DefaultAgent
+    from garuda.model.protocol import ModelResponse
+    from garuda.model.script_model import ScriptModel
+    from garuda.sdk import SoftwareAgent
+    from garuda.types import ToolCall
+
+    agent = SoftwareAgent(workspace=str(tmp_path), model="script/test", agent="build", mode="standard")
+
+    import garuda.interfaces.runner as runner_mod
+
+    orig = runner_mod.resolve_environment
+
+    async def local_env(*args, **kwargs):
+        from garuda.workspace.local import LocalEnvironment
+
+        env = LocalEnvironment(workspace_root=tmp_path)
+        return env, None
+
+    runner_mod.resolve_environment = local_env
+
+    import garuda.sdk.software_agent as sdk_mod
+
+    orig_model = sdk_mod.LitellmModel
+    sdk_mod.LitellmModel = lambda model_name, **kw: ScriptModel(
+        [
+            ModelResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(id="1", name="task_complete", arguments={"summary": "SDK smoke test completed fine."})
+                ],
+            )
+        ]
+    )
+    try:
+        result = await agent.run("sdk smoke test")
+    finally:
+        sdk_mod.LitellmModel = orig_model
+        runner_mod.resolve_environment = orig
+
+    assert result.success


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Major capability upgrade to v1.1.0 — coding agent features inspired by OpenCode, OpenHands, and Goose.

## New capabilities

- **agent.md** — OpenCode-compatible markdown agent profiles with YAML frontmatter
- **Skills** — Universal `SKILL.md` format, auto-discovered and injected into prompts
- **Software Agent SDK** — `garuda.sdk.SoftwareAgent` and `Conversation` (OpenHands-style)
- **Document tools** — `read_pdf`, `read_spreadsheet` via `[docs]` extra
- **Tool registry** — `register_tool()` for custom tools with permission rules
- **Subagents** — Isolated events + profile-specific permissions per subagent
- **Permissions** — `path_rules` and `bash_rules` in agent config
- **MCP** — `${ENV_VAR}` interpolation in MCP server config
- **Context** — Keeps recent turns after summarization for better continuity

## Tests

45 passed, 1 skipped
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1ca9-7194-776f-aca4-ee48d0cf1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1ca9-7194-776f-aca4-ee48d0cf1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

