### PR TITLE
fix: entry-point parity, MCP lifecycle, and multi-turn context

### DIFF
--- a/garuda/agents/setup.py
+++ b/garuda/agents/setup.py
@@ -1,0 +1,36 @@
+"""Shared agent profile setup for run, serve, recipes, and eval entry points."""
+
+from pathlib import Path
+
+from garuda.agents.loader import AgentProfile, load_profile, resolve_system_prompt
+from garuda.core.permissions import PermissionEngine
+from garuda.core.rigorous import create_agent
+from garuda.tools import build_toolkit
+from garuda.types import AgentConfig
+
+
+async def prepare_agent_run(
+    agent_name: str,
+    *,
+    workspace: str,
+    agents_dir: Path | None = None,
+    mcp_config_path: str | None = None,
+    mode: str = "standard",
+    approval_handler=None,
+) -> tuple[AgentProfile, AgentConfig, PermissionEngine, list, object, object | None]:
+    """Load profile, resolve skills, build toolkit, and return run dependencies."""
+    profile = load_profile(agent_name, extra_dir=agents_dir)
+    config = profile.to_agent_config()
+    config.mode = mode
+    config.system_prompt = resolve_system_prompt(profile, workspace)
+    mcp_path = mcp_config_path or config.mcp_config_path
+    permissions = PermissionEngine(
+        mode=config.permission_mode,
+        tool_rules=profile.tool_rules,
+        path_rules=profile.path_rules,
+        bash_rules=profile.bash_rules,
+        approval_handler=approval_handler,
+    )
+    tools, mcp_manager = await build_toolkit(profile.tools, mcp_path)
+    agent = create_agent(profile.name, mode=mode)
+    return profile, config, permissions, tools, agent, mcp_manager

--- a/garuda/config/recipes.py
+++ b/garuda/config/recipes.py
@@ -7,14 +7,11 @@ from typing import Any
 
 import yaml
 
-from garuda.agents.loader import load_profile
+from garuda.agents.loader import resolve_system_prompt
+from garuda.agents.setup import prepare_agent_run
 from garuda.core.events import EventStore
-from garuda.core.loop import DefaultAgent
-from garuda.core.permissions import PermissionEngine
-from garuda.core.rigorous import create_agent
 from garuda.model.protocol import Model
-from garuda.tools import build_toolkit
-from garuda.types import AgentConfig, AgentResult
+from garuda.types import AgentResult
 from garuda.workspace.protocol import Environment
 
 _TEMPLATE_PATTERN = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
@@ -118,14 +115,15 @@ async def run_recipe(
         if prior_context:
             prompt = f"{prompt}\n\n## Prior step output\n{prior_context}"
 
-        profile = load_profile(step.agent, extra_dir=agents_dir)
-        config = profile.to_agent_config()
-        config.mode = step.mode
-        if step.agent == "plan":
-            config.enable_verifier = False
-        permissions = PermissionEngine(mode=config.permission_mode, tool_rules=profile.tool_rules)
-        tools, mcp_manager = await build_toolkit(profile.tools, mcp_config_path)
-        agent = create_agent(profile.name, mode=step.mode)
+        profile, config, permissions, tools, agent, mcp_manager = await prepare_agent_run(
+            step.agent,
+            workspace=workspace,
+            agents_dir=agents_dir,
+            mcp_config_path=mcp_config_path,
+            mode=step.mode,
+        )
+        config.enable_verifier = step.agent != "plan"
+        config.system_prompt = resolve_system_prompt(profile, workspace)
 
         result = await agent.run(
             task=prompt,
@@ -135,6 +133,7 @@ async def run_recipe(
             config=config,
             events=events,
             permissions=permissions,
+            agents_dir=agents_dir,
         )
         if mcp_manager is not None:
             await mcp_manager.close()

--- a/garuda/core/loop.py
+++ b/garuda/core/loop.py
@@ -52,6 +52,7 @@ class DefaultAgent:
         hooks: HookRegistry | None = None,
         subagent_runner=None,
         agents_dir=None,
+        context: ContextManager | None = None,
     ) -> AgentResult:
         config = config or AgentConfig()
         events = events or EventStore()
@@ -68,21 +69,22 @@ class DefaultAgent:
             tool_map = {name: tool_map[name] for name in allowed if name in tool_map}
             tools = list(tool_map.values())
 
-        system_prompt = config.system_prompt or DEFAULT_SYSTEM_PROMPT
-        context = ContextManager(
-            model=model,
-            max_output_bytes=config.max_output_bytes,
-            proactive_threshold=config.proactive_summarize_threshold,
-            max_context_tokens=config.max_context_tokens,
-            enable_three_step_summary=config.enable_three_step_summary,
-            task=task,
-        )
-        context.seed(
-            [
-                Message(role=Role.SYSTEM, content=system_prompt),
-                Message(role=Role.USER, content=task),
-            ]
-        )
+        if context is None:
+            system_prompt = config.system_prompt or DEFAULT_SYSTEM_PROMPT
+            context = ContextManager(
+                model=model,
+                max_output_bytes=config.max_output_bytes,
+                proactive_threshold=config.proactive_summarize_threshold,
+                max_context_tokens=config.max_context_tokens,
+                enable_three_step_summary=config.enable_three_step_summary,
+                task=task,
+            )
+            context.seed(
+                [
+                    Message(role=Role.SYSTEM, content=system_prompt),
+                    Message(role=Role.USER, content=task),
+                ]
+            )
         events.append(EventType.USER_MESSAGE, {"content": task})
 
         if subagent_runner is None and "invoke_subagent" in tool_map:
@@ -95,6 +97,7 @@ class DefaultAgent:
                 agents_dir=agents_dir,
                 skills_dirs=config.skills_dirs,
                 workspace_root=getattr(env, "workspace_root", None),
+                parent_messages=context.get_messages(),
             )
 
         ctx = ToolContext(

--- a/garuda/core/rigorous.py
+++ b/garuda/core/rigorous.py
@@ -44,6 +44,7 @@ class RigorousAgent:
         permissions: PermissionEngine | None = None,
         hooks: HookRegistry | None = None,
         subagent_runner=None,
+        agents_dir=None,
     ) -> AgentResult:
         config = config or AgentConfig(mode="rigorous")
         events = events or EventStore()
@@ -86,6 +87,7 @@ class RigorousAgent:
             permissions=permissions,
             hooks=hooks,
             subagent_runner=subagent_runner,
+            agents_dir=agents_dir,
         )
 
         approved, feedback = await self._critic_review(task, plan_result.final_message, exec_result, model)

--- a/garuda/core/subagent.py
+++ b/garuda/core/subagent.py
@@ -1,7 +1,9 @@
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 
-from garuda.agents.loader import load_profile
+from garuda.agents.loader import load_profile, resolve_system_prompt
+from garuda.context.manager import ContextManager
 from garuda.core.events import EventStore, EventType
 from garuda.core.permissions import PermissionEngine
 from garuda.model.protocol import Model
@@ -22,8 +24,13 @@ class SubagentRunner:
     fork_parent_context: bool = False
     parent_messages: list[Message] | None = None
 
-    async def run(self, profile_name: str, task: str) -> AgentResult:
-        from garuda.agents.loader import resolve_system_prompt
+    async def run(
+        self,
+        profile_name: str,
+        task: str,
+        *,
+        fork_parent_context: bool | None = None,
+    ) -> AgentResult:
         from garuda.core.loop import DefaultAgent
 
         profile = load_profile(profile_name, extra_dir=self.agents_dir)
@@ -45,6 +52,25 @@ class SubagentRunner:
         sub_events = EventStore()
         agent = DefaultAgent(profile_name=profile.name)
 
+        use_fork = self.fork_parent_context if fork_parent_context is None else fork_parent_context
+        context: ContextManager | None = None
+        if use_fork and self.parent_messages:
+            context = ContextManager(
+                model=self.model,
+                max_output_bytes=config.max_output_bytes,
+                proactive_threshold=config.proactive_summarize_threshold,
+                max_context_tokens=config.max_context_tokens,
+                enable_three_step_summary=False,
+                task=task,
+            )
+            context.seed(deepcopy(self.parent_messages))
+            context.append(
+                Message(
+                    role=Role.USER,
+                    content=f"[subagent:{profile_name}] {task}",
+                )
+            )
+
         result = await agent.run(
             task=task,
             model=self.model,
@@ -53,6 +79,7 @@ class SubagentRunner:
             config=config,
             events=sub_events,
             permissions=permissions,
+            context=context,
         )
         if mcp_manager is not None:
             await mcp_manager.close()

--- a/garuda/eval/harbor_adapter.py
+++ b/garuda/eval/harbor_adapter.py
@@ -6,16 +6,15 @@ from typing import Any, override
 
 import yaml
 
-from garuda.agents.loader import load_profile
+from garuda.agents.setup import prepare_agent_run
 from garuda.core.events import EventStore
-from garuda.core.loop import DefaultAgent
 from garuda.core.permissions import PermissionEngine
 from garuda.eval.atif_export import events_to_atif, save_atif_trajectory
 from garuda.eval.harbor_environment import HarborEnvironmentAdapter
 from garuda.model.litellm_model import LitellmModel
 from garuda.model.protocol import ModelResponse
 from garuda.tools import build_toolkit
-from garuda.types import AgentConfig, Message
+from garuda.types import Message
 
 try:
     from harbor.agents.base import BaseAgent
@@ -120,27 +119,35 @@ class GarudaHarborAgent(BaseAgent):
         context: AgentContext,
     ) -> None:
         adapter = HarborEnvironmentAdapter(environment)
-        await adapter.resolve_workspace_root()
+        workspace_root = await adapter.resolve_workspace_root()
 
-        profile = load_profile(self._agent_profile)
-        config = profile.to_agent_config()
+        profile, config, permissions, tools, agent, mcp_manager = await prepare_agent_run(
+            self._agent_profile,
+            workspace=workspace_root,
+            mode="standard",
+        )
         config.enable_verifier = True
         config.workspace_kind = "local"
         if self._max_turns is not None:
             config.max_turns = self._max_turns
         if self._permission_mode:
             config.permission_mode = self._permission_mode
+            permissions = PermissionEngine(
+                mode=config.permission_mode,
+                tool_rules=profile.tool_rules,
+                path_rules=profile.path_rules,
+                bash_rules=profile.bash_rules,
+            )
 
         if not self.model_name:
             raise ValueError("GarudaHarborAgent requires --model (provider/model_name)")
 
         model = _UsageTrackingModel(LitellmModel(model_name=self.model_name))
-        permissions = PermissionEngine(mode=config.permission_mode, tool_rules=profile.tool_rules)
         events = EventStore()
-        agent = DefaultAgent(profile_name=profile.name)
 
         mcp_path = await self._write_mcp_config()
-        tools, mcp_manager = await build_toolkit(profile.tools, mcp_path)
+        if mcp_path:
+            tools, mcp_manager = await build_toolkit(profile.tools, mcp_path)
 
         result = await agent.run(
             task=instruction,

--- a/garuda/interfaces/cli.py
+++ b/garuda/interfaces/cli.py
@@ -1,13 +1,8 @@
 import asyncio
 from pathlib import Path
 
-from garuda.agents.loader import load_profile
-from garuda.core.events import EventStore
-from garuda.core.loop import DefaultAgent
-from garuda.core.permissions import PermissionEngine
 from garuda.interfaces.runner import run_agent_task
-from garuda.model.litellm_model import LitellmModel
-from garuda.tools import build_toolkit
+from garuda.interfaces.session import AgentSession
 
 
 async def stdin_approval(action: str) -> bool:
@@ -17,44 +12,56 @@ async def stdin_approval(action: str) -> bool:
 
 
 async def chat_loop(args) -> int:
-    model = LitellmModel(model_name=args.model)
-    profile = load_profile(args.agent, extra_dir=Path(args.agents_dir) if args.agents_dir else None)
-    config = profile.to_agent_config()
-    config.workspace_kind = getattr(args, "workspace_kind", "local")
-    config.docker_image = getattr(args, "docker_image", "ubuntu:22.04")
-    mcp_path = getattr(args, "mcp_config", None) or config.mcp_config_path
-    permissions = PermissionEngine(
-        mode=profile.permission_mode,
-        tool_rules=profile.tool_rules,
-        approval_handler=stdin_approval if profile.permission_mode == "smart" else None,
-    )
-    tools, mcp_manager = await build_toolkit(profile.tools, mcp_path)
-    agent = DefaultAgent(profile_name=profile.name)
+    agents_dir = Path(args.agents_dir) if args.agents_dir else None
+    from garuda.agents.loader import load_profile
 
-    print(f"Garuda chat — agent={profile.name} model={args.model} workspace={config.workspace_kind}")
+    profile = load_profile(args.agent, extra_dir=agents_dir)
+    approval = stdin_approval if profile.permission_mode == "smart" else None
+
+    session = await AgentSession.create(
+        agent_name=args.agent,
+        model=args.model,
+        workspace=args.workspace,
+        agents_dir=agents_dir,
+        mcp_config_path=getattr(args, "mcp_config", None),
+        mode=getattr(args, "mode", "standard"),
+        approval_handler=approval,
+        workspace_kind=getattr(args, "workspace_kind", "local"),
+        docker_image=getattr(args, "docker_image", "ubuntu:22.04"),
+        docker_host=getattr(args, "docker_host", None),
+    )
+
+    print(
+        f"Garuda chat — agent={session.profile.name} model={args.model} "
+        f"workspace={session.config.workspace_kind}"
+    )
     print("Enter a task (empty line to quit).\n")
 
     while True:
         print("task> ", end="", flush=True)
         task = await asyncio.to_thread(input)
         if not task.strip():
-            if mcp_manager:
-                await mcp_manager.close()
+            await session.close()
             print("Bye.")
             return 0
 
+        context = session.prepare_context(task.strip())
         result = await run_agent_task(
             task=task.strip(),
-            model=model,
-            agent=agent,
-            tools=tools,
-            config=config,
-            permissions=permissions,
+            model=session.model,
+            agent=session.agent,
+            tools=session.tools,
+            config=session.config,
+            permissions=session.permissions,
             workspace=args.workspace,
-            events=EventStore(),
+            events=session.events,
             emit_json=args.json,
-            workspace_kind=config.workspace_kind,
-            docker_image=config.docker_image,
-            mcp_manager=mcp_manager,
+            workspace_kind=session.config.workspace_kind,
+            docker_image=session.config.docker_image,
+            docker_host=session.config.docker_host,
+            mcp_manager=session.mcp_manager,
+            agents_dir=session.agents_dir,
+            context=context,
+            close_mcp=False,
         )
         print(f"\n{result.final_message}\n")

--- a/garuda/interfaces/main.py
+++ b/garuda/interfaces/main.py
@@ -54,6 +54,7 @@ def build_parser():
     chat_parser.add_argument("--agent", default="build")
     chat_parser.add_argument("--agents-dir")
     chat_parser.add_argument("--mcp-config")
+    chat_parser.add_argument("--mode", choices=["standard", "rigorous", "readonly"], default="standard")
     chat_parser.add_argument("--json", action="store_true")
 
     serve_parser = subparsers.add_parser("serve", help="Start JSON-RPC HTTP server for IDE integrations")
@@ -69,6 +70,8 @@ def build_parser():
     )
     serve_parser.add_argument("--docker-image", default="ubuntu:22.04")
     serve_parser.add_argument("--docker-host")
+    serve_parser.add_argument("--agents-dir")
+    serve_parser.add_argument("--mcp-config")
 
     recipe_parser = subparsers.add_parser("recipe", help="Run YAML workflow recipes")
     recipe_sub = recipe_parser.add_subparsers(dest="recipe_command")
@@ -221,6 +224,8 @@ async def run_serve(args) -> int:
         workspace_kind=args.workspace_kind,
         docker_image=args.docker_image,
         docker_host=args.docker_host,
+        agents_dir=args.agents_dir,
+        mcp_config=args.mcp_config,
     )
     await serve(config)
     return 0

--- a/garuda/interfaces/runner.py
+++ b/garuda/interfaces/runner.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from garuda.context.manager import ContextManager
 from garuda.core.events import EventStore
 from garuda.core.permissions import PermissionEngine
 from garuda.plugins.hooks import HookRegistry
@@ -55,6 +56,8 @@ async def run_agent_task(
     hooks: HookRegistry | None = None,
     mcp_manager=None,
     agents_dir=None,
+    context: ContextManager | None = None,
+    close_mcp: bool = True,
 ) -> AgentResult:
     env, handle = await resolve_environment(
         workspace_kind, workspace, docker_image, docker_host=docker_host
@@ -70,10 +73,11 @@ async def run_agent_task(
             permissions=permissions,
             hooks=hooks,
             agents_dir=agents_dir,
+            context=context,
         )
     finally:
         await cleanup_workspace(handle)
-        if mcp_manager is not None:
+        if close_mcp and mcp_manager is not None:
             await mcp_manager.close()
     if emit_json:
         for event in events.get_all():

--- a/garuda/interfaces/server.py
+++ b/garuda/interfaces/server.py
@@ -6,10 +6,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from garuda.agents.loader import load_profile
+from garuda.agents.loader import list_profiles
+from garuda.agents.setup import prepare_agent_run
 from garuda.core.events import EventStore
-from garuda.core.permissions import PermissionEngine
-from garuda.core.rigorous import create_agent
 from garuda.interfaces.runner import run_agent_task
 from garuda.model.litellm_model import LitellmModel
 
@@ -24,6 +23,8 @@ class ServerConfig:
     workspace_kind: str = "local"
     docker_image: str = "ubuntu:22.04"
     docker_host: str | None = None
+    agents_dir: str | None = None
+    mcp_config: str | None = None
 
 
 class JsonRpcServer:
@@ -43,9 +44,12 @@ class JsonRpcServer:
             elif method == "run":
                 result = await self._run(params)
             elif method == "list_agents":
-                from garuda.agents.loader import list_profiles
-
-                result = {"agents": list_profiles()}
+                agents_dir = params.get("agents_dir", self._config.agents_dir)
+                result = {
+                    "agents": list_profiles(
+                        extra_dir=Path(agents_dir) if agents_dir else None
+                    )
+                }
             else:
                 raise ValueError(f"Unknown method: {method}")
             return {"jsonrpc": "2.0", "id": req_id, "result": result}
@@ -74,21 +78,23 @@ class JsonRpcServer:
         agent_name = params.get("agent", self._config.agent)
         mode = params.get("mode", "standard")
         workspace_kind = params.get("workspace_kind", self._config.workspace_kind)
+        workspace = params.get("workspace", self._config.workspace)
+        agents_dir = params.get("agents_dir", self._config.agents_dir)
+        mcp_config = params.get("mcp_config", self._config.mcp_config)
+        agents_path = Path(agents_dir) if agents_dir else None
 
-        profile = load_profile(agent_name)
-        config = profile.to_agent_config()
-        config.mode = mode
+        profile, config, permissions, tools, agent, mcp_manager = await prepare_agent_run(
+            agent_name,
+            workspace=workspace,
+            agents_dir=agents_path,
+            mcp_config_path=mcp_config,
+            mode=mode,
+        )
         config.workspace_kind = workspace_kind
         config.docker_image = params.get("docker_image", self._config.docker_image)
 
         model = LitellmModel(model_name=model_name)
-        permissions = PermissionEngine(mode=config.permission_mode, tool_rules=profile.tool_rules)
-        agent = create_agent(profile.name, mode=mode)
         events = EventStore()
-
-        from garuda.tools import build_toolkit
-
-        tools, mcp_manager = await build_toolkit(profile.tools, config.mcp_config_path)
         result = await run_agent_task(
             task=task,
             model=model,
@@ -96,12 +102,13 @@ class JsonRpcServer:
             tools=tools,
             config=config,
             permissions=permissions,
-            workspace=params.get("workspace", self._config.workspace),
+            workspace=workspace,
             events=events,
             workspace_kind=workspace_kind,
             docker_image=config.docker_image,
             docker_host=params.get("docker_host", self._config.docker_host),
             mcp_manager=mcp_manager,
+            agents_dir=agents_path,
         )
 
         return {

--- a/garuda/interfaces/session.py
+++ b/garuda/interfaces/session.py
@@ -1,0 +1,100 @@
+"""Shared agent session state for multi-turn CLI and SDK conversations."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from garuda.agents.loader import AgentProfile, load_profile, resolve_system_prompt
+from garuda.context.manager import ContextManager
+from garuda.core.events import EventStore
+from garuda.core.permissions import PermissionEngine
+from garuda.core.rigorous import create_agent
+from garuda.model.litellm_model import LitellmModel
+from garuda.tools import build_toolkit
+from garuda.types import AgentConfig, Message, Role
+
+ApprovalHandler = Callable[[str], Awaitable[bool]]
+
+
+@dataclass
+class AgentSession:
+    """Holds tools, permissions, events, and conversation context across turns."""
+
+    profile: AgentProfile
+    config: AgentConfig
+    model: LitellmModel
+    permissions: PermissionEngine
+    tools: list
+    agent: object
+    events: EventStore = field(default_factory=EventStore)
+    mcp_manager: object | None = None
+    agents_dir: Path | None = None
+    context: ContextManager | None = None
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        agent_name: str,
+        model: str,
+        workspace: str,
+        agents_dir: Path | None = None,
+        mcp_config_path: str | None = None,
+        mode: str = "standard",
+        approval_handler: ApprovalHandler | None = None,
+        workspace_kind: str = "local",
+        docker_image: str = "ubuntu:22.04",
+        docker_host: str | None = None,
+    ) -> "AgentSession":
+        profile = load_profile(agent_name, extra_dir=agents_dir)
+        config = profile.to_agent_config()
+        config.mode = mode
+        config.workspace_kind = workspace_kind
+        config.docker_image = docker_image
+        config.docker_host = docker_host
+        config.system_prompt = resolve_system_prompt(profile, workspace)
+        mcp_path = mcp_config_path or config.mcp_config_path
+        permissions = PermissionEngine(
+            mode=profile.permission_mode,
+            tool_rules=profile.tool_rules,
+            path_rules=profile.path_rules,
+            bash_rules=profile.bash_rules,
+            approval_handler=approval_handler,
+        )
+        tools, mcp_manager = await build_toolkit(profile.tools, mcp_path)
+        return cls(
+            profile=profile,
+            config=config,
+            model=LitellmModel(model_name=model),
+            permissions=permissions,
+            tools=tools,
+            mcp_manager=mcp_manager,
+            agents_dir=agents_dir,
+            agent=create_agent(profile.name, mode=mode),
+        )
+
+    def prepare_context(self, task: str) -> ContextManager:
+        """Seed or extend the shared LLM context for a new user turn."""
+        if self.context is None:
+            self.context = ContextManager(
+                model=self.model,
+                max_output_bytes=self.config.max_output_bytes,
+                proactive_threshold=self.config.proactive_summarize_threshold,
+                max_context_tokens=self.config.max_context_tokens,
+                enable_three_step_summary=self.config.enable_three_step_summary,
+                task=task,
+            )
+            self.context.seed(
+                [
+                    Message(role=Role.SYSTEM, content=self.config.system_prompt or ""),
+                    Message(role=Role.USER, content=task),
+                ]
+            )
+        else:
+            self.context.append(Message(role=Role.USER, content=task))
+        return self.context
+
+    async def close(self) -> None:
+        if self.mcp_manager is not None:
+            await self.mcp_manager.close()
+            self.mcp_manager = None

--- a/garuda/mcp/client.py
+++ b/garuda/mcp/client.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from typing import Any
@@ -9,6 +10,8 @@ from mcp.client.stdio import stdio_client
 from garuda.mcp.config import McpServerConfig, load_mcp_config
 from garuda.tools.protocol import Tool, ToolContext
 from garuda.types import ToolResult
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -62,6 +65,11 @@ class McpClientManager:
             return
         for server in servers:
             if server.transport != "stdio":
+                logger.warning(
+                    "Skipping non-stdio MCP server %s (transport=%s)",
+                    server.name,
+                    server.transport,
+                )
                 continue
             params = StdioServerParameters(
                 command=server.command,

--- a/garuda/sdk/conversation.py
+++ b/garuda/sdk/conversation.py
@@ -2,19 +2,15 @@
 
 from pathlib import Path
 
-from garuda.agents.loader import load_profile, resolve_system_prompt
 from garuda.core.events import EventStore
-from garuda.core.loop import DefaultAgent
-from garuda.core.permissions import PermissionEngine
-from garuda.core.rigorous import create_agent
-from garuda.model.litellm_model import LitellmModel
-from garuda.tools import build_toolkit
-from garuda.types import AgentConfig, AgentResult
+from garuda.interfaces.runner import run_agent_task
+from garuda.interfaces.session import AgentSession
+from garuda.types import AgentResult
 from garuda.workspace.local import LocalEnvironment
 
 
 class Conversation:
-    """Multi-turn Garuda session with shared event history."""
+    """Multi-turn Garuda session with shared event history and LLM context."""
 
     def __init__(
         self,
@@ -26,52 +22,49 @@ class Conversation:
         mode: str = "standard",
     ):
         self._workspace = str(workspace)
-        self._model = LitellmModel(model_name=model)
+        self._model_name = model
         self._agent_name = agent
         self._agents_dir = Path(agents_dir) if agents_dir else None
         self._mcp_config = mcp_config
         self._mode = mode
-        self._events = EventStore()
+        self._session: AgentSession | None = None
         self._env = LocalEnvironment(workspace_root=self._workspace)
-        self._tools = None
-        self._mcp_manager = None
-        self._profile = load_profile(agent, extra_dir=self._agents_dir)
 
-    async def _ensure_tools(self) -> None:
-        if self._tools is None:
-            config = self._profile.to_agent_config()
-            mcp_path = self._mcp_config or config.mcp_config_path
-            self._tools, self._mcp_manager = await build_toolkit(self._profile.tools, mcp_path)
+    async def _ensure_session(self) -> AgentSession:
+        if self._session is None:
+            self._session = await AgentSession.create(
+                agent_name=self._agent_name,
+                model=self._model_name,
+                workspace=self._workspace,
+                agents_dir=self._agents_dir,
+                mcp_config_path=self._mcp_config,
+                mode=self._mode,
+            )
+        return self._session
 
     async def run(self, task: str) -> AgentResult:
         """Run a task in this conversation."""
-        await self._ensure_tools()
-        config = self._profile.to_agent_config()
-        config.mode = self._mode
-        config.system_prompt = resolve_system_prompt(self._profile, self._workspace)
-        permissions = PermissionEngine(
-            mode=config.permission_mode,
-            tool_rules=self._profile.tool_rules,
-            path_rules=self._profile.path_rules,
-            bash_rules=self._profile.bash_rules,
-        )
-        agent = create_agent(self._profile.name, mode=self._mode)
-        return await agent.run(
+        session = await self._ensure_session()
+        context = session.prepare_context(task)
+        return await session.agent.run(
             task=task,
-            model=self._model,
+            model=session.model,
             env=self._env,
-            tools=self._tools or [],
-            config=config,
-            events=self._events,
-            permissions=permissions,
-            agents_dir=self._agents_dir,
+            tools=session.tools,
+            config=session.config,
+            events=session.events,
+            permissions=session.permissions,
+            agents_dir=session.agents_dir,
+            context=context,
         )
 
     async def close(self) -> None:
-        if self._mcp_manager is not None:
-            await self._mcp_manager.close()
-            self._mcp_manager = None
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
 
     @property
     def events(self) -> EventStore:
-        return self._events
+        if self._session is None:
+            return EventStore()
+        return self._session.events

--- a/garuda/tools/subagent.py
+++ b/garuda/tools/subagent.py
@@ -17,6 +17,11 @@ class InvokeSubagentTool:
                 "description": "Subagent profile name (explore, plan, or custom)",
             },
             "task": {"type": "string", "description": "Task for the subagent"},
+            "fork_context": {
+                "type": "boolean",
+                "description": "Include parent conversation history in the subagent context",
+                "default": False,
+            },
         },
         "required": ["profile", "task"],
     }
@@ -37,7 +42,8 @@ class InvokeSubagentTool:
 
         profile = arguments["profile"]
         task = arguments["task"]
-        result = await ctx.subagent_runner.run(profile, task)
+        fork_context = bool(arguments.get("fork_context", False))
+        result = await ctx.subagent_runner.run(profile, task, fork_parent_context=fork_context)
         summary = format_subagent_summary(profile, result)
         return ToolResult(
             tool_call_id="",

--- a/tests/test_phase8.py
+++ b/tests/test_phase8.py
@@ -1,0 +1,239 @@
+"""Tests for entry-point parity, MCP lifecycle, and multi-turn context."""
+
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from garuda.agents.setup import prepare_agent_run
+from garuda.context.manager import ContextManager
+from garuda.core.events import EventStore
+from garuda.core.loop import DefaultAgent
+from garuda.core.permissions import PermissionEngine
+from garuda.interfaces.runner import run_agent_task
+from garuda.interfaces.session import AgentSession
+from garuda.mcp.client import McpClientManager
+from garuda.mcp.config import McpServerConfig
+from garuda.model.protocol import ModelResponse
+from garuda.model.script_model import ScriptModel
+from garuda.sdk.conversation import Conversation
+from garuda.types import AgentConfig, Message, Role, ToolCall
+from garuda.workspace.local import LocalEnvironment
+
+
+@pytest.mark.asyncio
+async def test_run_agent_task_preserves_mcp_when_close_mcp_false(tmp_path):
+    manager = MagicMock()
+    manager.close = AsyncMock()
+    env = LocalEnvironment(workspace_root=tmp_path)
+    model = ScriptModel(
+        [
+            ModelResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(id="1", name="task_complete", arguments={"summary": "done"})
+                ],
+            )
+        ]
+    )
+    agent = DefaultAgent()
+    config = AgentConfig()
+
+    import garuda.interfaces.runner as runner_mod
+
+    async def fake_resolve(*args, **kwargs):
+        return env, None
+
+    original = runner_mod.resolve_environment
+    runner_mod.resolve_environment = fake_resolve
+    try:
+        await run_agent_task(
+            task="test",
+            model=model,
+            agent=agent,
+            tools=[],
+            config=config,
+            permissions=PermissionEngine(mode="auto"),
+            workspace=str(tmp_path),
+            events=EventStore(),
+            mcp_manager=manager,
+            close_mcp=False,
+        )
+        manager.close.assert_not_called()
+    finally:
+        runner_mod.resolve_environment = original
+
+
+@pytest.mark.asyncio
+async def test_agent_session_multi_turn_context(tmp_path):
+    session = await AgentSession.create(
+        agent_name="build",
+        model="script/test",
+        workspace=str(tmp_path),
+    )
+    session.model = ScriptModel(
+        [
+            ModelResponse(content="first reply", tool_calls=[]),
+            ModelResponse(content="second reply", tool_calls=[]),
+        ]
+    )
+
+    session.prepare_context("first task")
+    assert len(session.context.get_messages()) == 2
+
+    session.prepare_context("second task")
+    messages = session.context.get_messages()
+    assert len(messages) == 3
+    assert messages[-1].content == "second task"
+
+
+@pytest.mark.asyncio
+async def test_conversation_carries_llm_context(tmp_path):
+    conversation = Conversation(workspace=str(tmp_path), model="script/test", agent="build")
+    model = ScriptModel(
+        [
+            ModelResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(id="1", name="task_complete", arguments={"summary": "turn one done"})
+                ],
+            ),
+            ModelResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(id="2", name="task_complete", arguments={"summary": "turn two done"})
+                ],
+            ),
+        ]
+    )
+
+    import garuda.interfaces.session as session_mod
+
+    original_create = session_mod.AgentSession.create
+
+    async def patched_create(**kwargs):
+        session = await original_create(**kwargs)
+        session.model = model
+        return session
+
+    session_mod.AgentSession.create = patched_create
+    try:
+        result1 = await conversation.run("task one")
+        result2 = await conversation.run("task two")
+    finally:
+        session_mod.AgentSession.create = original_create
+
+    assert result1.final_message == "turn one done"
+    assert result2.final_message == "turn two done"
+    assert conversation._session is not None
+    assert conversation._session.context is not None
+    assert any(m.content == "task two" for m in conversation._session.context.get_messages())
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_run_includes_path_rules(tmp_path):
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    (agents_dir / "secure.yaml").write_text(
+        "name: secure\npermission_mode: smart\n"
+        "path_rules:\n  deny: ['**/.env']\n"
+        "tools: [read_file, task_complete]\n",
+        encoding="utf-8",
+    )
+    profile, config, permissions, tools, agent, mcp_manager = await prepare_agent_run(
+        "secure",
+        workspace=str(tmp_path),
+        agents_dir=agents_dir,
+    )
+    allowed, _ = await permissions.evaluate_tool_call("read_file", {"path": ".env"})
+    assert not allowed
+    if mcp_manager is not None:
+        await mcp_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_default_agent_uses_provided_context(tmp_path):
+    env = LocalEnvironment(workspace_root=tmp_path)
+    model = ScriptModel(
+        [
+            ModelResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(id="1", name="task_complete", arguments={"summary": "continued"})
+                ],
+            )
+        ]
+    )
+    context = ContextManager(model=model, task="prior")
+    context.seed(
+        [
+            Message(role=Role.SYSTEM, content="system"),
+            Message(role=Role.USER, content="prior task"),
+            Message(role=Role.ASSISTANT, content="prior answer"),
+        ]
+    )
+    from garuda.tools import tools_for_names
+
+    agent = DefaultAgent()
+    result = await agent.run(
+        task="follow up",
+        model=model,
+        env=env,
+        tools=tools_for_names(["task_complete"]),
+        config=AgentConfig(enable_verifier=False),
+        context=context,
+    )
+    assert result.final_message == "continued"
+    assert len(context.get_messages()) >= 3
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_warns_on_non_stdio(caplog):
+    caplog.set_level(logging.WARNING)
+    manager = McpClientManager()
+    await manager.start(
+        [
+            McpServerConfig(name="remote", transport="sse", command="echo", args=[]),
+        ]
+    )
+    assert manager.get_tools() == []
+    assert "Skipping non-stdio MCP server remote" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_recipe_step_uses_path_rules(tmp_path):
+    from garuda.config.recipes import Recipe, RecipeStep, run_recipe
+
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    (agents_dir / "plan.yaml").write_text(
+        "name: plan\npermission_mode: smart\n"
+        "path_rules:\n  deny: ['**/secret.txt']\n"
+        "tools: [read_file, task_complete]\n",
+        encoding="utf-8",
+    )
+    recipe = Recipe(
+        name="test",
+        steps=[RecipeStep(agent="plan", prompt="inspect {{target}}", mode="standard")],
+    )
+    env = LocalEnvironment(workspace_root=tmp_path)
+    model = ScriptModel(
+        [
+            ModelResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(id="1", name="read_file", arguments={"path": "secret.txt"})
+                ],
+            )
+        ]
+    )
+    results = await run_recipe(
+        recipe,
+        {"target": "secret.txt"},
+        model=model,
+        env=env,
+        workspace=str(tmp_path),
+        agents_dir=agents_dir,
+    )
+    assert len(results) == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes all parity gaps identified in the v1.1.0 code review so every entry point (`garuda run`, `garuda chat`, `garuda serve`, recipes, Harbor, SDK) wires skills, permissions, and agent setup consistently.

## Changes

- **MCP lifecycle**: `run_agent_task` accepts `close_mcp=False` so `garuda chat` no longer tears down MCP after the first turn
- **AgentSession / prepare_agent_run**: shared helpers for skills injection, path/bash rules, toolkit setup, and rigorous agent creation
- **Multi-turn context**: `DefaultAgent.run()` accepts an optional `ContextManager`; chat and `Conversation` SDK persist LLM history across turns
- **CLI chat**: full parity with `garuda run` (skills, permissions, `agents_dir`, `--mode`)
- **JSON-RPC server**: skills, path/bash rules, `agents_dir`, `mcp_config` support
- **Recipes & Harbor**: use `prepare_agent_run` with full permissions and skills
- **Subagents**: `fork_context` tool argument forks parent conversation history when requested
- **MCP client**: logs warnings for non-stdio transports (matching Harbor behavior)

## Tests

- Added `tests/test_phase8.py` (7 tests)
- Full suite: **52 passed, 1 skipped**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1ca9-7194-776f-aca4-ee48d0cf1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1ca9-7194-776f-aca4-ee48d0cf1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

